### PR TITLE
feat: add parameterized query support

### DIFF
--- a/sqlplugin/driver.go
+++ b/sqlplugin/driver.go
@@ -1,0 +1,209 @@
+package sqlplugin
+
+import (
+	"database/sql"
+)
+
+// DriverType represents the type of database driver
+type DriverType string
+
+const (
+	DriverMSSQL  DriverType = "mssql"
+	DriverSQLite DriverType = "sqlite"
+)
+
+// DriverExecutor defines the interface for database-specific SQL execution
+type DriverExecutor interface {
+	// Execute runs a parameterized SQL query
+	Execute(sqlTmpl string, params map[string]interface{}) (*DataSet, error)
+
+	// ExecuteBatch runs multiple SQL statements in a transaction
+	ExecuteBatch(statements []string, params []map[string]interface{}) error
+
+	// DB returns the underlying database connection
+	DB() *sql.DB
+}
+
+// MSSQLExecutor implements DriverExecutor for MSSQL
+type MSSQLExecutor struct {
+	db        *sql.DB
+	extractor *ParamExtractor
+}
+
+// NewMSSQLExecutor creates a new MSSQL executor
+func NewMSSQLExecutor(db *sql.DB) *MSSQLExecutor {
+	return &MSSQLExecutor{
+		db:        db,
+		extractor: NewParamExtractor(),
+	}
+}
+
+// Execute runs a parameterized SQL query on MSSQL
+func (e *MSSQLExecutor) Execute(sqlTmpl string, params map[string]interface{}) (*DataSet, error) {
+	// Convert @name to MSSQL format with named args
+	sqlStr, namedArgs, err := e.extractor.ExtractNamed(sqlTmpl, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.query(sqlStr, namedArgs)
+}
+
+// ExecuteBatch executes multiple statements in a transaction
+func (e *MSSQLExecutor) ExecuteBatch(statements []string, params []map[string]interface{}) error {
+	tx, err := e.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i, stmt := range statements {
+		var p map[string]interface{}
+		if i < len(params) {
+			p = params[i]
+		}
+
+		sqlStr, namedArgs, err := e.extractor.ExtractNamed(stmt, p)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(sqlStr, namedArgs...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// DB returns the underlying database connection
+func (e *MSSQLExecutor) DB() *sql.DB {
+	return e.db
+}
+
+func (e *MSSQLExecutor) query(sqlStr string, args []interface{}) (*DataSet, error) {
+	rows, err := e.db.Query(sqlStr, args...)
+	if err != nil {
+		return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	// Get column names
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+	}
+
+	// Scan results
+	var resultRows [][]interface{}
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		valuePtrs := make([]interface{}, len(columns))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		err := rows.Scan(valuePtrs...)
+		if err != nil {
+			return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+		}
+		resultRows = append(resultRows, values)
+	}
+
+	return &DataSet{
+		Columns: columns,
+		Rows:    resultRows,
+	}, nil
+}
+
+// SQLiteExecutor implements DriverExecutor for SQLite
+type SQLiteExecutor struct {
+	db        *sql.DB
+	extractor *ParamExtractor
+}
+
+// NewSQLiteExecutor creates a new SQLite executor
+func NewSQLiteExecutor(db *sql.DB) *SQLiteExecutor {
+	return &SQLiteExecutor{
+		db:        db,
+		extractor: NewParamExtractor(),
+	}
+}
+
+// Execute runs a parameterized SQL query on SQLite
+func (e *SQLiteExecutor) Execute(sqlTmpl string, params map[string]interface{}) (*DataSet, error) {
+	// Convert @name to ? placeholders
+	sqlStr, args, err := e.extractor.Extract(sqlTmpl, params, OptionPlaceholders)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.query(sqlStr, args)
+}
+
+// ExecuteBatch executes multiple statements in a transaction
+func (e *SQLiteExecutor) ExecuteBatch(statements []string, params []map[string]interface{}) error {
+	tx, err := e.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i, stmt := range statements {
+		var p map[string]interface{}
+		if i < len(params) {
+			p = params[i]
+		}
+
+		sqlStr, args, err := e.extractor.Extract(stmt, p, OptionPlaceholders)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(sqlStr, args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// DB returns the underlying database connection
+func (e *SQLiteExecutor) DB() *sql.DB {
+	return e.db
+}
+
+func (e *SQLiteExecutor) query(sqlStr string, args []interface{}) (*DataSet, error) {
+	rows, err := e.db.Query(sqlStr, args...)
+	if err != nil {
+		return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+	}
+
+	var resultRows [][]interface{}
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		valuePtrs := make([]interface{}, len(columns))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		err := rows.Scan(valuePtrs...)
+		if err != nil {
+			return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
+		}
+		resultRows = append(resultRows, values)
+	}
+
+	return &DataSet{
+		Columns: columns,
+		Rows:    resultRows,
+	}, nil
+}

--- a/sqlplugin/errors.go
+++ b/sqlplugin/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrInvalidConfig     = fmt.Errorf("invalid plugin configuration")
 	ErrMissingField      = fmt.Errorf("missing required field")
 	ErrInvalidSQL        = fmt.Errorf("invalid SQL template")
+	ErrMissingParameter = fmt.Errorf("missing parameter in SQL template")
 	ErrSQLFileNotFound   = fmt.Errorf("SQL file not found")
 	ErrExecutionFailed  = fmt.Errorf("SQL execution failed")
 	ErrRoutingFailed    = fmt.Errorf("result routing failed")

--- a/sqlplugin/executor.go
+++ b/sqlplugin/executor.go
@@ -7,27 +7,40 @@ import (
 )
 
 // Executor executes SQL templates with parameter substitution
+// It supports both string substitution and driver-based parameterized execution
 type Executor struct {
-	db *sql.DB
+	db     *sql.DB
+	driver DriverExecutor
 }
 
 // NewExecutor creates a new SQL template executor
+// For backwards compatibility, uses string substitution by default
 func NewExecutor(db *sql.DB) *Executor {
 	return &Executor{db: db}
 }
 
-// Execute executes a SQL template with parameters
+// NewExecutorWithDriver creates a new executor with a specific driver
+// dbType: "mssql" or "sqlite"
+func NewExecutorWithDriver(db *sql.DB, dbType DriverType) *Executor {
+	var driver DriverExecutor
+	switch dbType {
+	case DriverMSSQL:
+		driver = NewMSSQLExecutor(db)
+	case DriverSQLite:
+		driver = NewSQLiteExecutor(db)
+	default:
+		panic("unsupported driver type: " + string(dbType) + "")
+	}
+	return &Executor{db: db, driver: driver}
+}
+
+// Execute executes a SQL template with parameters using string substitution
+// For backwards compatibility - considers using ExecuteDriver for parameterized queries
 func (e *Executor) Execute(sqlTmpl string, params CDCParameters) (*DataSet, error) {
 	// Substitute parameters
 	sql, err := e.substituteParams(sqlTmpl, params)
 	if err != nil {
-		return nil, NewExecutionError(sqlTmpl, map[string]interface{}{
-			"cdc_lsn": params.CDCLSN,
-			"cdc_tx_id": params.CDCTxID,
-			"cdc_table": params.CDCTable,
-			"cdc_operation": params.CDCOperation,
-			"fields": params.Fields,
-		}, err)
+		return nil, NewExecutionError(sqlTmpl, nil, err)
 	}
 
 	// Execute query
@@ -44,6 +57,15 @@ func (e *Executor) Execute(sqlTmpl string, params CDCParameters) (*DataSet, erro
 	}
 
 	return ds, nil
+}
+
+// ExecuteDriver executes a SQL template using driver-based parameterized queries
+// This is the preferred method for security (SQL injection prevention)
+func (e *Executor) ExecuteDriver(sqlTmpl string, params map[string]interface{}) (*DataSet, error) {
+	if e.driver == nil {
+		panic("driver not configured - use NewExecutorWithDriver")
+	}
+	return e.driver.Execute(sqlTmpl, params)
 }
 
 // ExecuteStages executes multi-step SQL stages

--- a/sqlplugin/param.go
+++ b/sqlplugin/param.go
@@ -1,0 +1,111 @@
+package sqlplugin
+
+import (
+	"database/sql"
+	"regexp"
+)
+
+// Parameter represents a named parameter in SQL template
+type Parameter struct {
+	Name  string // @orders_order_id
+	Value interface{}
+}
+
+// ParamExtractor extracts @name parameters from SQL templates
+// and converts them to driver-specific parameter formats
+type ParamExtractor struct {
+	pattern *regexp.Regexp
+}
+
+// NewParamExtractor creates a new parameter extractor
+func NewParamExtractor() *ParamExtractor {
+	return &ParamExtractor{
+		pattern: regexp.MustCompile(`@([a-zA-Z_][a-zA-Z0-9_]*)`),
+	}
+}
+
+// ExtractParamNames extracts all parameter names from SQL template in order
+func (e *ParamExtractor) ExtractParamNames(sqlTmpl string) []string {
+	matches := e.pattern.FindAllStringSubmatch(sqlTmpl, -1)
+	names := make([]string, 0, len(matches))
+	seen := make(map[string]bool)
+
+	for _, match := range matches {
+		if len(match) >= 2 {
+			name := match[1]
+			if !seen[name] {
+				names = append(names, name)
+				seen[name] = true
+			}
+		}
+	}
+	return names
+}
+
+// ExtractOption defines how to convert @name parameters
+type ExtractOption int
+
+const (
+	// OptionPlaceholders converts @name to ? (for SQLite)
+	OptionPlaceholders ExtractOption = iota
+	// OptionKeepNames keeps @name (for MSSQL)
+	OptionKeepNames
+)
+
+// Extract converts SQL template to driver-specific format
+// sqlTmpl: SELECT * FROM orders WHERE order_id = @orders_order_id
+// params: map of parameter name → value
+// Returns: converted SQL, args/named args, error
+func (e *ParamExtractor) Extract(sqlTmpl string, params map[string]interface{}, opt ExtractOption) (string, []interface{}, error) {
+	names := e.ExtractParamNames(sqlTmpl)
+
+	switch opt {
+	case OptionPlaceholders:
+		// SQLite: @name → ?
+		args := make([]interface{}, len(names))
+		for i, name := range names {
+			args[i] = params[name]
+		}
+		sql := e.pattern.ReplaceAllString(sqlTmpl, "?")
+		return sql, args, nil
+
+	case OptionKeepNames:
+		// MSSQL: keep @name, use named args
+		args := make([]interface{}, len(names))
+		for i, name := range names {
+			args[i] = sql.NamedArg{Name: name, Value: params[name]}
+		}
+		return sqlTmpl, args, nil
+
+	default:
+		return e.Extract(sqlTmpl, params, OptionPlaceholders)
+	}
+}
+
+// ExtractNamed extracts parameters for MSSQL named args
+func (e *ParamExtractor) ExtractNamed(sqlTmpl string, params map[string]interface{}) (string, []interface{}, error) {
+	names := e.ExtractParamNames(sqlTmpl)
+
+	namedArgs := make([]interface{}, len(names))
+	for i, name := range names {
+		namedArgs[i] = sql.NamedArg{Name: name, Value: params[name]}
+	}
+
+	return sqlTmpl, namedArgs, nil
+}
+
+// ReplacePlaceholders replaces @name with ? in SQL template
+func (e *ParamExtractor) ReplacePlaceholders(sqlTmpl string) string {
+	return e.pattern.ReplaceAllString(sqlTmpl, "?")
+}
+
+// Validate checks if all @name parameters in SQL have corresponding values
+func (e *ParamExtractor) Validate(sqlTmpl string, params map[string]interface{}) error {
+	names := e.ExtractParamNames(sqlTmpl)
+	for _, name := range names {
+		if _, ok := params[name]; !ok {
+			return ErrMissingParameter
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Add support for SQL parameterization to prevent injection and handle type conversion properly.

### Changes

1. **param.go**: ParameterExtractor for @name parsing
   - ExtractParamNames: extracts @name from SQL template
   - Extract: converts to driver-specific format (? or @name)
   - ExtractNamed: for MSSQL named args

2. **driver.go**: DriverExecutor interface
   - MSSQLExecutor: uses @name with named args
   - SQLiteExecutor: converts @name → ?
   - ExecuteBatch: transaction support

3. **executor.go**: Add ExecuteDriver method

### Usage



### Benefits
- SQL injection prevention
- Proper type handling
- Consistent @name syntax across databases
- DB-specific conversion in driver layer