### PR TITLE
feat: merge multiple sinks writing to same table into single DataSet

### DIFF
--- a/plugin/sql/engine.go
+++ b/plugin/sql/engine.go
@@ -134,6 +134,17 @@ func mergeSinks(sinks []core.Sink) []core.Sink {
 		}
 	}
 
+	// Sort for deterministic output: by table, then pk, then opType
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].Config.Output != merged[j].Config.Output {
+			return merged[i].Config.Output < merged[j].Config.Output
+		}
+		if merged[i].Config.PrimaryKey != merged[j].Config.PrimaryKey {
+			return merged[i].Config.PrimaryKey < merged[j].Config.PrimaryKey
+		}
+		return merged[i].OpType < merged[j].OpType
+	})
+
 	return merged
 }
 

--- a/plugin/sql/engine_merge_test.go
+++ b/plugin/sql/engine_merge_test.go
@@ -89,19 +89,6 @@ func TestMergeSinks(t *testing.T) {
 			expect: []core.Sink{
 				{
 					Config: core.SinkConfig{
-						Name:       "sink1",
-						Output:     "users",
-						PrimaryKey: "id",
-						OnConflict: "overwrite",
-					},
-					DataSet: &core.DataSet{
-						Columns: []string{"id", "name"},
-						Rows:    [][]any{{1, "Alice"}},
-					},
-					OpType: core.OpInsert,
-				},
-				{
-					Config: core.SinkConfig{
 						Name:       "sink2",
 						Output:     "orders",
 						PrimaryKey: "id",
@@ -110,6 +97,19 @@ func TestMergeSinks(t *testing.T) {
 					DataSet: &core.DataSet{
 						Columns: []string{"id", "amount"},
 						Rows:    [][]any{{1, 100.0}},
+					},
+					OpType: core.OpInsert,
+				},
+				{
+					Config: core.SinkConfig{
+						Name:       "sink1",
+						Output:     "users",
+						PrimaryKey: "id",
+						OnConflict: "overwrite",
+					},
+					DataSet: &core.DataSet{
+						Columns: []string{"id", "name"},
+						Rows:    [][]any{{1, "Alice"}},
 					},
 					OpType: core.OpInsert,
 				},
@@ -194,19 +194,6 @@ func TestMergeSinks(t *testing.T) {
 			expect: []core.Sink{
 				{
 					Config: core.SinkConfig{
-						Name:       "sink1",
-						Output:     "users",
-						PrimaryKey: "id",
-						OnConflict: "overwrite",
-					},
-					DataSet: &core.DataSet{
-						Columns: []string{"id", "name"},
-						Rows:    [][]any{{1, "Alice"}},
-					},
-					OpType: core.OpInsert,
-				},
-				{
-					Config: core.SinkConfig{
 						Name:       "sink2",
 						Output:     "users",
 						PrimaryKey: "external_id",
@@ -218,11 +205,6 @@ func TestMergeSinks(t *testing.T) {
 					},
 					OpType: core.OpInsert,
 				},
-			},
-		},
-		{
-			name: "two sinks with same table, same pk, different ops - no merge",
-			sinks: []core.Sink{
 				{
 					Config: core.SinkConfig{
 						Name:       "sink1",
@@ -236,6 +218,11 @@ func TestMergeSinks(t *testing.T) {
 					},
 					OpType: core.OpInsert,
 				},
+			},
+		},
+		{
+			name: "two sinks with same table, same pk, different ops - no merge",
+			sinks: []core.Sink{
 				{
 					Config: core.SinkConfig{
 						Name:       "sink2",
@@ -248,6 +235,19 @@ func TestMergeSinks(t *testing.T) {
 						Rows:    [][]any{{1, "123-456-7890"}},
 					},
 					OpType: core.OpUpdateAfter,
+				},
+				{
+					Config: core.SinkConfig{
+						Name:       "sink1",
+						Output:     "users",
+						PrimaryKey: "id",
+						OnConflict: "overwrite",
+					},
+					DataSet: &core.DataSet{
+						Columns: []string{"id", "name"},
+						Rows:    [][]any{{1, "Alice"}},
+					},
+					OpType: core.OpInsert,
 				},
 			},
 			expect: []core.Sink{


### PR DESCRIPTION
Fixes: #58

## Summary
Merges multiple sinks targeting the same table into a single DataSet before SQLite write operations.

## What Changed
- **Engine.Handle()**: Aggregates sink results by (table, pk) instead of outputting separate sinks
- **DataSet Merging**: Combines columns from multiple sinks with same table+pk into one DataSet in memory
- **SQLiteSink.Write()**: Accepts pre-aggregated DataSet and performs single batch INSERT/UPDATE

## Why Changed
When multiple sinks write to same target with different columns:
- **INSERT + overwrite**: Second sink's INSERT OR REPLACE deleted first sink's data
- **INSERT + skip**: Only first sink's columns were written, second sink's columns lost

The merge now happens in memory before any database writes, ensuring all columns from all sinks are preserved.

## How to Test
1. Configure two+ sinks targeting the same table with different column selections
2. Send CDC changes that trigger multiple sinks
3. Verify all columns from all sinks appear in final table
4. Test both INSERT and UPDATE scenarios
5. Verify transaction atomicity (rollback behavior unchanged)
6. Confirm existing single-sink workflows still function