### PR TITLE
fix: dashboard Last Sync time display - parse string timestamp correctly

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -927,9 +927,14 @@ func (s *Server) collectOverviewMetrics() OverviewMetrics {
 			metrics.CDCStatus = "active"
 			metrics.CDCMessage = "CDC polling active"
 			
-			// Get last sync time
-			if lastPoll, ok := state["last_poll_time"].(time.Time); ok {
-				metrics.LastSyncTime = lastPoll.Format("2006-01-02 15:04:05")
+			// Get last sync time (stored as string in DB)
+			if lastPollStr, ok := state["last_poll_time"].(string); ok && lastPollStr != "" {
+				// Parse the timestamp string and format for display
+				if lastPoll, err := time.Parse("2006-01-02 15:04:05.999999999", lastPollStr); err == nil {
+					metrics.LastSyncTime = lastPoll.Format("2006-01-02 15:04:05")
+				} else {
+					metrics.LastSyncTime = lastPollStr
+				}
 			}
 			
 			// Count tracked tables


### PR DESCRIPTION
## Problem

Dashboard 'Last Sync' field always showed current time or was empty.

## Root Cause

Type mismatch in `collectOverviewMetrics()`:

```go
// Expected: time.Time
if lastPoll, ok := state["last_poll_time"].(time.Time); ok {
    metrics.LastSyncTime = lastPoll.Format("2006-01-02 15:04:05")
}
```

But `GetPollerState()` returns **string** (from SQL NULLABLE string):

```go
// Actual: string
if lastPollTime.Valid {
    state["last_poll_time"] = lastPollTime.String
}
```

The type assertion always failed, so `LastSyncTime` was never set.

## Fix

Parse the string timestamp properly:

```go
if lastPollStr, ok := state["last_poll_time"].(string); ok && lastPollStr != "" {
    // Parse the timestamp string and format for display
    if lastPoll, err := time.Parse("2006-01-02 15:04:05.999999999", lastPollStr); err == nil {
        metrics.LastSyncTime = lastPoll.Format("2006-01-02 15:04:05")
    } else {
        metrics.LastSyncTime = lastPollStr
    }
}
```

## Testing

- ✅ Build succeeds
- ✅ All tests pass
- ✅ Type matching corrected
- ✅ Dashboard will now show actual last poll time from database