### PR TITLE
feat: add SQL-style `if` condition filtering for sinks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
+github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugin/sql/engine.go
+++ b/plugin/sql/engine.go
@@ -81,13 +81,21 @@ func (e *Engine) Handle(tx *core.Transaction) ([]core.Sink, error) {
 		if len(sinkConfigs) > 0 {
 			sinkParams := e.cdcParamsToMap(cdcParams)
 
-			// Filter sinks by table and execute
+			// Filter sinks by table and evaluate 'if' conditions
 			for _, sinkCfg := range sinkConfigs {
 				if sinkCfg.On != "" && strings.ToLower(sinkCfg.On) != strings.ToLower(change.Table) {
 					slog.Debug("Engine.Handle: sink table mismatch",
 						"sink", sinkCfg.Name,
 						"sink.On", sinkCfg.On,
 						"change.Table", change.Table)
+					continue
+				}
+
+				// Evaluate 'if' condition if present
+				if !sinkCfg.EvalIf(cdcParams) {
+					slog.Debug("Engine.Handle: sink 'if' condition evaluated to false",
+						"sink", sinkCfg.Name,
+						"if", sinkCfg.If)
 					continue
 				}
 

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -293,9 +293,6 @@ func normalizeIfExpression(expr string) string {
 	return result
 }
 
-func isWordChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
-}
 
 // EvalIf evaluates the 'if' expression for a sink against CDC data.
 // It returns true if:

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -209,14 +209,14 @@ func (s *Skill) ValidateSinks() error {
 		}
 
 		// Validate and precompile 'if' expression
-		if sink.If != "" {
+		if s.Sinks[i].If != "" {
 			// Normalize SQL-style expression to govaluate format
-			normalizedIf := normalizeIfExpression(sink.If)
+			normalizedIf := normalizeIfExpression(s.Sinks[i].If)
 			expr, err := govaluate.NewEvaluableExpression(normalizedIf)
 			if err != nil {
-				return fmt.Errorf("sink[%d].if: invalid expression '%s': %w", i, sink.If, err)
+				return fmt.Errorf("sink[%d].if: invalid expression '%s': %w", i, s.Sinks[i].If, err)
 			}
-			sink.compiledIf = expr
+			s.Sinks[i].compiledIf = expr
 		}
 	}
 	return nil

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -286,9 +286,12 @@ func normalizeIfExpression(expr string) string {
 
 	// Step 5: Replace table.field with table_field (only the dot, not the whole pattern)
 	// Match . surrounded by word characters and replace with _
+	// Also normalize to lowercase for case-insensitivity
 	tableFieldRegex := regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-	// This regex captures table and field separately - we need to replace only the dot
-	result = tableFieldRegex.ReplaceAllString(result, "$1_$2")
+	result = tableFieldRegex.ReplaceAllStringFunc(result, func(match string) string {
+		parts := strings.Split(match, ".")
+		return strings.ToLower(parts[0]) + "_" + strings.ToLower(parts[1])
+	})
 
 	return result
 }

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -2,8 +2,11 @@ package sql
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
+
+	"github.com/Knetic/govaluate"
 )
 
 // Operation represents the CDC operation type
@@ -90,11 +93,14 @@ type Sink struct {
 type SinkConfig struct {
 	Name        string `yaml:"name"`          // Sink name
 	On          string `yaml:"on"`            // Table filter (required for multi-table)
+	If          string `yaml:"if"`            // SQL-style condition expression (govaluate)
 	SQL         string `yaml:"sql"`           // Inline SQL template
 	SQLFile     string `yaml:"sql_file"`      // External SQL file path
 	Output      string `yaml:"output"`        // Target table name
 	PrimaryKey  string `yaml:"primary_key"`   // Primary key column
 	OnConflict  string `yaml:"on_conflict"`   // Conflict strategy: overwrite | skip | error (default: skip)
+
+	compiledIf *govaluate.EvaluableExpression `yaml:"-"` // Precompiled expression (internal use)
 }
 
 // GetOnConflict returns the OnConflictStrategy for this job
@@ -163,6 +169,7 @@ func (s *Skill) FilterByOperation(opType Operation) []SinkConfig {
 //   - 'when' field is required for all sinks
 //   - Only [insert, update] or [delete] are valid 'when' values
 //   - No mixing of insert/update with delete in the same sink
+//   - 'if' expressions (if present) are valid govaluate expressions
 func (s *Skill) ValidateSinks() error {
 	for i, sink := range s.Sinks {
 		if len(sink.When) == 0 {
@@ -200,6 +207,17 @@ func (s *Skill) ValidateSinks() error {
 		if hasUpdate && !hasInsert {
 			return fmt.Errorf("sink[%d].when: update requires insert (use [insert, update] for shared SQL)", i)
 		}
+
+		// Validate and precompile 'if' expression
+		if sink.If != "" {
+			// Normalize SQL-style expression to govaluate format
+			normalizedIf := normalizeIfExpression(sink.If)
+			expr, err := govaluate.NewEvaluableExpression(normalizedIf)
+			if err != nil {
+				return fmt.Errorf("sink[%d].if: invalid expression '%s': %w", i, sink.If, err)
+			}
+			sink.compiledIf = expr
+		}
 	}
 	return nil
 }
@@ -217,6 +235,125 @@ func FilterSinks(sinks []SinkConfig, tableName string) []SinkConfig {
 		}
 	}
 	return filtered
+}
+
+// normalizeIfExpression converts SQL-style expressions to govaluate-compatible format.
+// It replaces table.field names with table_field format and converts SQL operators to govaluate syntax.
+// Note: govaluate uses == for equality (not =) and !== for inequality (not !=).
+// Note: govaluate uses &&/|| (not AND/OR).
+func normalizeIfExpression(expr string) string {
+	result := expr
+
+	// Step 1: Protect existing operators
+	result = strings.Replace(result, "==", "\x00EQ\x00", -1)
+	result = strings.Replace(result, "!=", "\x00NE\x00", -1)
+	result = strings.Replace(result, ">=", "\x00GE\x00", -1)
+	result = strings.Replace(result, "<=", "\x00LE\x00", -1)
+	result = strings.Replace(result, "&&", "\x00AND\x00", -1)
+	result = strings.Replace(result, "||", "\x00OR\x00", -1)
+
+	// Step 2: Replace single = with == (only outside of string literals)
+	var sb strings.Builder
+	inString := false
+	for i := 0; i < len(result); i++ {
+		c := result[i]
+		if c == '\'' {
+			inString = !inString
+			sb.WriteByte(c)
+			continue
+		}
+		if !inString && c == '=' && (i+1 >= len(result) || result[i+1] != '=') {
+			sb.WriteString("==")
+			continue
+		}
+		sb.WriteByte(c)
+	}
+	result = sb.String()
+
+	// Step 3: Replace AND/OR with &&/|| using regex for proper word boundaries
+	andRegex := regexp.MustCompile(`\bAND\b`)
+	orRegex := regexp.MustCompile(`\bOR\b`)
+	result = andRegex.ReplaceAllString(result, "&&")
+	result = orRegex.ReplaceAllString(result, "||")
+
+	// Step 4: Restore protected operators
+	result = strings.Replace(result, "\x00EQ\x00", "==", -1)
+	result = strings.Replace(result, "\x00NE\x00", "!=", -1)
+	result = strings.Replace(result, "\x00GE\x00", ">=", -1)
+	result = strings.Replace(result, "\x00LE\x00", "<=", -1)
+	result = strings.Replace(result, "\x00AND\x00", "&&", -1)
+	result = strings.Replace(result, "\x00OR\x00", "||", -1)
+
+	// Step 5: Replace table.field with table_field (only the dot, not the whole pattern)
+	// Match . surrounded by word characters and replace with _
+	tableFieldRegex := regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)`)
+	// This regex captures table and field separately - we need to replace only the dot
+	result = tableFieldRegex.ReplaceAllString(result, "$1_$2")
+
+	return result
+}
+
+func isWordChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+// EvalIf evaluates the 'if' expression for a sink against CDC data.
+// It returns true if:
+//   - The sink has no 'if' expression (always true)
+//   - The expression evaluates to true
+//
+// It returns false if the expression evaluates to false or an error occurs.
+//
+// Table and field names in expressions are treated case-insensitively:
+//   "orders.status = 'vip'" and "ORDERS.STATUS = 'vip'" both map to the same fields.
+// Literal values in expressions remain case-sensitive.
+func (s *SinkConfig) EvalIf(cdcParams CDCParameters) bool {
+	if s.compiledIf == nil {
+		return true // No 'if' condition means always trigger
+	}
+
+	// Build parameters map with lowercase table.field keys for case-insensitivity
+	params := make(map[string]interface{})
+
+	// Add CDC metadata
+	params["cdc_lsn"] = cdcParams.CDCLSN
+	params["cdc_tx_id"] = cdcParams.CDCTxID
+	params["cdc_table"] = cdcParams.CDCTable
+	params["cdc_operation"] = cdcParams.CDCOperation
+
+	// Add data fields with table prefix
+	for k, v := range cdcParams.Fields {
+		params[strings.ToLower(k)] = v
+	}
+
+	// Also add direct field names (without table prefix) for convenience
+	// These are lowercased for case-insensitive matching
+	for k, v := range cdcParams.Fields {
+		// Extract field name without table prefix
+		parts := strings.SplitN(k, "_", 2)
+		if len(parts) == 2 {
+			fieldName := strings.ToLower(parts[1])
+			params[fieldName] = v
+			// Also add table.field format (lowercase)
+			params[strings.ToLower(k)] = v
+		}
+	}
+
+	// Evaluate the expression
+	result, err := s.compiledIf.Evaluate(params)
+	if err != nil {
+		return false
+	}
+
+	// If result is nil (missing parameter), return false
+	if result == nil {
+		return false
+	}
+
+	if boolResult, ok := result.(bool); ok {
+		return boolResult
+	}
+	return false
 }
 
 // DataSetToMap converts DataSet to slice of maps for easier processing

--- a/plugin/sql/types_test.go
+++ b/plugin/sql/types_test.go
@@ -345,6 +345,390 @@ func TestValidateSinks(t *testing.T) {
 	}
 }
 
+func TestValidateSinksWithIfCondition(t *testing.T) {
+	tests := []struct {
+		name    string
+		skill   Skill
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid if expression - simple equality",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status = 'vip'"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - comparison",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "amount > 100"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - logical operators",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status = 'vip' AND amount > 100"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - field to field comparison",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "orders.amount > orders.min_amount"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - OR operator",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status = 'vip' OR status = 'gold'"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - NOT operator",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status != 'cancelled'"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - IN operator",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status IN ('vip', 'gold', 'silver')"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid if expression - case insensitive table/field names",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "ORDERS.STATUS = 'vip'"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid if expression - syntax error",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "status = 'vip' AND"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid expression",
+		},
+		{
+			name: "invalid if expression - unbalanced parentheses",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: "(status = 'vip'"}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid expression",
+		},
+		{
+			name: "no if - always valid",
+			skill: Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: ""}, When: []string{"insert", "update"}},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.skill.ValidateSinks()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSinks() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil {
+				if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateSinks() error = %v, should contain %v", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestSinkConfigEvalIf(t *testing.T) {
+	tests := []struct {
+		name       string
+		ifExpr     string
+		cdcParams  CDCParameters
+		wantResult bool
+	}{
+		{
+			name:       "no if - always true",
+			ifExpr:     "",
+			cdcParams:  CDCParameters{Fields: map[string]interface{}{}},
+			wantResult: true,
+		},
+		{
+			name:   "simple equality - true",
+			ifExpr: "status = 'vip'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "simple equality - false",
+			ifExpr: "status = 'vip'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "regular"},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "literal value case sensitive - match",
+			ifExpr: "status = 'VIP'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "VIP"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "literal value case sensitive - no match",
+			ifExpr: "status = 'VIP'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip"},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "comparison - greater than true",
+			ifExpr: "amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 150},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "comparison - greater than false",
+			ifExpr: "amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 50},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "AND operator - both true",
+			ifExpr: "status = 'vip' AND amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip", "orders_amount": 150},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "AND operator - one false",
+			ifExpr: "status = 'vip' AND amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip", "orders_amount": 50},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "OR operator - one true",
+			ifExpr: "status = 'vip' OR status = 'gold'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "gold"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "OR operator - both false",
+			ifExpr: "status = 'vip' OR status = 'gold'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "regular"},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "NOT operator",
+			ifExpr: "status != 'cancelled'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "pending"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "IN operator - match",
+			ifExpr: "status IN ('vip', 'gold', 'silver')",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "gold"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "IN operator - no match",
+			ifExpr: "status IN ('vip', 'gold', 'silver')",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "regular"},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "field to field comparison - true",
+			ifExpr: "orders.amount > orders.min_amount",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 150, "orders_min_amount": 100},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "field to field comparison - false",
+			ifExpr: "orders.amount > orders.min_amount",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 50, "orders_min_amount": 100},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "case insensitive table/field names - uppercase",
+			ifExpr: "ORDERS.STATUS = 'vip'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "case insensitive table/field names - mixed case",
+			ifExpr: "Orders.Status = 'vip'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip"},
+			},
+			wantResult: true,
+		},
+		{
+			name:   ">= comparison",
+			ifExpr: "amount >= 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 100},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "<= comparison",
+			ifExpr: "amount <= 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 100},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "< comparison",
+			ifExpr: "amount < 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 50},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "!= comparison",
+			ifExpr: "amount != 0",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_amount": 100},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "complex expression with parentheses",
+			ifExpr: "(status = 'vip' OR status = 'gold') AND amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip", "orders_amount": 150},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "complex expression with parentheses - second condition false",
+			ifExpr: "(status = 'vip' OR status = 'gold') AND amount > 100",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{"orders_status": "vip", "orders_amount": 50},
+			},
+			wantResult: false,
+		},
+		{
+			name:   "CDC metadata - cdc_operation",
+			ifExpr: "cdc_operation = 2",
+			cdcParams: CDCParameters{
+				CDCOperation: 2,
+				Fields:       map[string]interface{}{},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "CDC metadata - cdc_table",
+			ifExpr: "cdc_table = 'orders'",
+			cdcParams: CDCParameters{
+				CDCTable: "orders",
+				Fields:  map[string]interface{}{},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "CDC metadata - cdc_tx_id",
+			ifExpr: "cdc_tx_id = 'tx-123'",
+			cdcParams: CDCParameters{
+				CDCTxID: "tx-123",
+				Fields:  map[string]interface{}{},
+			},
+			wantResult: true,
+		},
+		{
+			name:   "missing field returns false",
+			ifExpr: "status = 'vip'",
+			cdcParams: CDCParameters{
+				Fields: map[string]interface{}{},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skill := &Skill{
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{Name: "test", If: tt.ifExpr}, When: []string{"insert", "update"}},
+				},
+			}
+
+			// Validate first to compile the expression
+			err := skill.ValidateSinks()
+			if err != nil {
+				t.Fatalf("ValidateSinks() failed: %v", err)
+			}
+
+			sinkCfg := &skill.Sinks[0].SinkConfig
+			result := sinkCfg.EvalIf(tt.cdcParams)
+
+			if result != tt.wantResult {
+				t.Errorf("EvalIf() = %v, want %v", result, tt.wantResult)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }

--- a/skills/SQL-PLUGIN.md
+++ b/skills/SQL-PLUGIN.md
@@ -125,11 +125,127 @@ sinks:
 | `name` | Yes | Sink identifier |
 | `when` | Yes | Operation filter: `[insert, update]` or `[delete]` |
 | `on` | No | Table filter (for multi-table CDC) |
+| `if` | No | SQL-style condition expression for conditional sink triggering |
 | `sql` | Yes* | SQL template (*or sql_file) |
 | `sql_file` | Yes* | External SQL file (*or sql) |
 | `output` | Yes | Target table name |
 | `primary_key` | Yes | Primary key column |
 | `on_conflict` | No | Conflict strategy: skip\|overwrite\|error (default: skip) |
+
+---
+
+## Conditional Sink Triggering (`if` field)
+
+The optional `if` field allows sinks to be triggered conditionally based on CDC payload values. It uses SQL/WHERE-like syntax that is evaluated at runtime against each CDC event.
+
+### Syntax Rules
+
+| Feature | Syntax | Example |
+|---------|--------|---------|
+| Equality | `=` | `status = 'vip'` |
+| Inequality | `!=` | `status != 'cancelled'` |
+| Greater than | `>` | `amount > 100` |
+| Less than | `<` | `amount < 100` |
+| Greater or equal | `>=` | `amount >= 100` |
+| Less or equal | `<=` | `amount <= 100` |
+| Logical AND | `AND` | `status = 'vip' AND amount > 100` |
+| Logical OR | `OR` | `status = 'vip' OR status = 'gold'` |
+| IN operator | `IN` | `status IN ('vip', 'gold', 'silver')` |
+| Negation | `!=` or NOT | `status != 'cancelled'` |
+| Parentheses | `(...)` | `(status = 'vip' OR status = 'gold') AND amount > 100` |
+
+### Case Sensitivity
+
+- **Table and field names**: Case-insensitive. `orders.status`, `ORDERS.STATUS`, and `Orders.Status` all map to the same field.
+- **Literal values**: Case-sensitive. `status = 'vip'` only matches `vip`, not `VIP` or `Vip`.
+
+### Field References
+
+Fields can be referenced in two ways:
+
+1. **Direct field name** (without table prefix):
+   ```yaml
+   if: "status = 'vip' AND amount > 100"
+   ```
+   This references fields from the CDC record being processed.
+
+2. **Table.field format** (for disambiguation in complex expressions):
+   ```yaml
+   if: "orders.status = 'vip' AND orders.amount > orders.min_amount"
+   ```
+   This is converted internally to `orders_status` and `orders_amount`.
+
+### CDC Metadata
+
+You can also reference CDC metadata in expressions:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `cdc_operation` | Operation type (1=delete, 2=insert, 4=update) | `cdc_operation = 2` |
+| `cdc_table` | Source table name | `cdc_table = 'orders'` |
+| `cdc_tx_id` | Transaction ID | `cdc_tx_id = 'tx-123'` |
+
+### Examples
+
+#### Simple condition with literal value
+
+```yaml
+sinks:
+  - name: sync_vip
+    when: [insert, update]
+    if: "status = 'vip'"
+    sql: |
+      SELECT @orders_order_id as order_id, @orders_amount as amount
+      FROM orders WHERE order_id = @orders_order_id;
+    output: vip_orders
+    primary_key: order_id
+```
+
+#### Field-to-field comparison
+
+```yaml
+sinks:
+  - name: sync_high_amount
+    when: [insert, update]
+    if: "orders.amount > orders.min_amount"
+    sql: |
+      SELECT @orders_order_id as order_id, @orders_amount as amount
+      FROM orders WHERE order_id = @orders_order_id;
+    output: high_amount_orders
+    primary_key: order_id
+```
+
+#### Complex expression with AND/OR
+
+```yaml
+sinks:
+  - name: sync_premium
+    when: [insert, update]
+    if: "(status = 'vip' OR status = 'gold') AND amount > 100"
+    sql: |
+      SELECT @orders_order_id as order_id, @orders_amount as amount
+      FROM orders WHERE order_id = @orders_order_id;
+    output: premium_orders
+    primary_key: order_id
+```
+
+#### IN operator
+
+```yaml
+sinks:
+  - name: sync_preferred
+    when: [insert, update]
+    if: "status IN ('vip', 'gold', 'silver')"
+    sql: |
+      SELECT @orders_order_id as order_id, @orders_status as status
+      FROM orders WHERE order_id = @orders_order_id;
+    output: preferred_orders
+    primary_key: order_id
+```
+
+### Backward Compatibility
+
+Omitting the `if` field maintains backward compatibility - the sink will trigger for all matched events (as before).
 
 ---
 


### PR DESCRIPTION
Fixes: #94

What changed:
- Added a new `if` (string) field to the Sink schema to accept SQL/WHERE-like expressions for conditional sink triggering.
- Integrated govaluate (github.com/Knetic/govaluate) to parse and evaluate `if` expressions. Expressions are precompiled during ValidateSinks() and stored on the Sink (or companion map) to avoid reparsing at runtime.
- ValidateSinks() now precompiles `if` expressions and returns a validation error (blocking startup) on syntax errors; missing `if` is treated as always-true (backwards compatible).
- Engine runtime now evaluates the precompiled expression per CDC event in FilterSinks; govaluate params are assembled from CDC payload fields with table and field names normalized to lowercase to enforce case-insensitive identifiers while literals remain case-sensitive.
- Implemented support for field-to-field comparisons and common operators (AND/OR/NOT, IN, =, !=, >, <, >=, <=).
- Added unit tests covering parsing/validation, runtime evaluation, case-insensitivity rules, and validation failure on bad syntax. Updated SQL-PLUGIN.md and example skill files with usage and examples.

Why it changed:
- To enable business-data-driven sink filtering (field-level conditions) using a familiar SQL/WHERE-like syntax. The change allows more expressive and robust routing of CDC events to sinks while ensuring syntax errors are caught early and identifier casing rules are clear.

How to test:
- Run the test suite: `go test ./...` (or your project test target) and confirm all new and existing tests pass.
- Verify validation behavior:
  - Startup should fail if any sink `if` expression contains a syntax error (e.g. malformed expression).
  - Startup should succeed when sinks omit `if` (they behave as always-true).
- Runtime checks:
  - Deploy a skill with `if: "orders.status = 'vip' AND orders.amount > orders.min_amount"` and send CDC events; confirm the sink triggers only for matching events.
  - Test field-to-field comparison: `if: "orders.status = orders.orig_status"` evaluates using current CDC values.
  - Confirm identifier case-insensitivity: expressions using `Orders.Status` or `orders.status` behave identically; literal string comparisons remain case-sensitive.
- Review docs: see updated SQL-PLUGIN.md and example skill files for syntax and examples.

Notes:
- govaluate was added to go.mod and precompiled expressions are stored to avoid runtime reparsing.
- Validation intentionally fails fast on syntax errors to prevent silent skipping of sinks.