### PR TITLE
feat: API返回时间根据mssql.timezone配置格式化

### DIFF
--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -167,6 +167,121 @@ function formatLocalTime(timeStr) {
 let currentLimit = 100;
 let filtersExpanded = false;
 
+// 工具函数（必须在调用前定义）
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function copyJson(button) {
+    const code = button.parentElement.querySelector('code');
+    if (code) {
+        navigator.clipboard.writeText(code.textContent).then(() => {
+            const originalHtml = button.innerHTML;
+            button.innerHTML = `
+                <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                </svg>
+            `;
+            setTimeout(() => {
+                button.innerHTML = originalHtml;
+            }, 2000);
+        });
+    }
+}
+
+function renderDesktopRow(log) {
+    const opStyle = {
+        'INSERT': 'bg-success/20 text-success border-success/30',
+        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
+        'DELETE': 'bg-error/20 text-error border-error/30'
+    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    
+    const dataPreview = JSON.stringify(log.data).substring(0, 150);
+    const dataFull = JSON.stringify(log.data, null, 2);
+    const isTruncated = dataFull.length > 150;
+    
+    return `
+        <tr class="hover:bg-surfaceHover transition-colors">
+            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[120px]">${escapeHtml(log.id)}</td>
+            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
+            <td class="px-6 py-4">
+                <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
+                    ${log.operation}
+                </span>
+            </td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
+            <td class="px-6 py-4 text-xs">
+                <details class="group">
+                    <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
+                        ${escapeHtml(dataPreview)}${isTruncated ? '...' : ''}
+                    </summary>
+                    <div class="mt-2 relative">
+                        <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto max-w-md text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
+                        <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                            </svg>
+                        </button>
+                    </div>
+                </details>
+            </td>
+        </tr>
+    `;
+}
+
+function renderMobileCard(log) {
+    const opStyle = {
+        'INSERT': 'bg-success/20 text-success border-success/30',
+        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
+        'DELETE': 'bg-error/20 text-error border-error/30'
+    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    
+    const dataFull = JSON.stringify(log.data, null, 2);
+    
+    return `
+        <div class="p-4 border-b border-border">
+            <div class="flex items-start justify-between gap-2">
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-2">
+                        <span class="font-medium text-text truncate">${escapeHtml(log.table_name)}</span>
+                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full border ${opStyle}">
+                            ${log.operation}
+                        </span>
+                    </div>
+                    <div class="text-xs text-textMuted">
+                        ID: ${escapeHtml(log.id)}
+                        <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
+                    </div>
+                    <div class="text-xs text-textMuted mt-1">
+                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
+                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
+                    </div>
+                    <details class="group mt-2">
+                        <summary class="cursor-pointer text-primary hover:text-primaryHover text-xs list-none flex items-center gap-1">
+                            <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                            </svg>
+                            View Data
+                        </summary>
+                        <div class="mt-2 relative">
+                            <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
+                            <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </details>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
 // Toggle filters on mobile
 function toggleFilters() {
     filtersExpanded = !filtersExpanded;
@@ -313,122 +428,6 @@ function loadLogs() {
                 </div>
             `;
         });
-}
-
-function renderDesktopRow(log) {
-    const opStyle = {
-        'INSERT': 'bg-success/20 text-success border-success/30',
-        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
-        'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
-    
-    const dataPreview = JSON.stringify(log.data).substring(0, 150);
-    const dataFull = JSON.stringify(log.data, null, 2);
-    const isTruncated = dataFull.length > 150;
-    
-    return `
-        <tr class="hover:bg-surfaceHover transition-colors">
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[120px]">${escapeHtml(log.id)}</td>
-            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4">
-                <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
-                    ${log.operation}
-                </span>
-            </td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
-            <td class="px-6 py-4 text-xs">
-                <details class="group">
-                    <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
-                        ${escapeHtml(dataPreview)}${isTruncated ? '...' : ''}
-                    </summary>
-                    <div class="mt-2 relative">
-                        <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto max-w-md text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
-                        <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-                            </svg>
-                        </button>
-                    </div>
-                </details>
-            </td>
-        </tr>
-    `;
-}
-
-function renderMobileCard(log) {
-    const opStyle = {
-        'INSERT': 'bg-success/20 text-success border-success/30',
-        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
-        'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
-    
-    const dataFull = JSON.stringify(log.data, null, 2);
-    
-    return `
-        <div class="p-4 hover:bg-surfaceHover transition-colors">
-            <div class="flex items-start justify-between gap-3 mb-3">
-                <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-2">
-                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full border ${opStyle}">
-                            ${log.operation}
-                        </span>
-                        <span class="font-medium text-text truncate">${escapeHtml(log.table_name)}</span>
-                    </div>
-                    <div class="flex items-center gap-2 text-xs text-textMuted">
-                        <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
-                    </div>
-                    <div class="flex flex-col gap-1 mt-2 text-xs">
-                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
-                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
-                    </div>
-                </div>
-            </div>
-            <details class="group">
-                <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors text-sm list-none flex items-center gap-2">
-                    <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-                    </svg>
-                    View Data
-                </summary>
-                <div class="mt-2 relative">
-                    <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
-                    <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-                        </svg>
-                    </button>
-                </div>
-            </details>
-        </div>
-    `;
-}
-
-function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-}
-
-// loadLogs 在页面加载时调用
-
-function copyJson(button) {
-    const code = button.parentElement.querySelector('code');
-    if (code) {
-        navigator.clipboard.writeText(code.textContent).then(() => {
-            // Show feedback
-            const originalHtml = button.innerHTML;
-            button.innerHTML = `
-                <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                </svg>
-            `;
-            setTimeout(() => {
-                button.innerHTML = originalHtml;
-            }, 2000);
-        });
-    }
 }
 
 // Initial load

--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -1,17 +1,5 @@
 <!--layout:dashboard-->
 {{ define "content" }}
-<script>
-// 时间格式化函数（必须在 loadLogs 之前定义）
-function formatLocalTime(timeStr) {
-    if (!timeStr) return '-';
-    try {
-        const date = new Date(timeStr);
-        return date.toLocaleString();
-    } catch {
-        return timeStr;
-    }
-}
-</script>
 <div class="space-y-4 sm:space-y-6">
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
@@ -212,8 +200,8 @@ function renderDesktopRow(log) {
                 </span>
             </td>
             <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${log.changed_at || '-'}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${log.pulled_at || '-'}</td>
             <td class="px-6 py-4 text-xs">
                 <details class="group">
                     <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
@@ -257,8 +245,8 @@ function renderMobileCard(log) {
                         <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
                     </div>
                     <div class="text-xs text-textMuted mt-1">
-                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
-                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
+                        <div><span class="text-textMuted">Changed:</span> ${log.changed_at || '-'}</div>
+                        <div><span class="text-textMuted">Pulled:</span> ${log.pulled_at || '-'}</div>
                     </div>
                     <details class="group mt-2">
                         <summary class="cursor-pointer text-primary hover:text-primaryHover text-xs list-none flex items-center gap-1">
@@ -310,7 +298,7 @@ function loadPollerStatus() {
         .then(data => {
             if (data.success && data.state) {
                 const state = data.state;
-                document.getElementById('last-poll-time').textContent = formatLocalTime(state.last_poll_time);
+                document.getElementById('last-poll-time').textContent = state.last_poll_time || '-';
                 document.getElementById('last-lsn').textContent = state.last_lsn || '-';
                 document.getElementById('total-changes').textContent = state.total_changes || 0;
             }

--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -1,5 +1,17 @@
 <!--layout:dashboard-->
 {{ define "content" }}
+<script>
+// 时间格式化函数（必须在 loadLogs 之前定义）
+function formatLocalTime(timeStr) {
+    if (!timeStr) return '-';
+    try {
+        const date = new Date(timeStr);
+        return date.toLocaleString();
+    } catch {
+        return timeStr;
+    }
+}
+</script>
 <div class="space-y-4 sm:space-y-6">
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
@@ -393,21 +405,13 @@ function renderMobileCard(log) {
     `;
 }
 
-function formatLocalTime(timeStr) {
-    if (!timeStr) return '-';
-    try {
-        const date = new Date(timeStr);
-        return date.toLocaleString();
-    } catch {
-        return timeStr;
-    }
-}
-
 function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
 }
+
+// loadLogs 在页面加载时调用
 
 function copyJson(button) {
     const code = button.parentElement.querySelector('code');

--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -155,121 +155,6 @@
 let currentLimit = 100;
 let filtersExpanded = false;
 
-// 工具函数（必须在调用前定义）
-function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-}
-
-function copyJson(button) {
-    const code = button.parentElement.querySelector('code');
-    if (code) {
-        navigator.clipboard.writeText(code.textContent).then(() => {
-            const originalHtml = button.innerHTML;
-            button.innerHTML = `
-                <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                </svg>
-            `;
-            setTimeout(() => {
-                button.innerHTML = originalHtml;
-            }, 2000);
-        });
-    }
-}
-
-function renderDesktopRow(log) {
-    const opStyle = {
-        'INSERT': 'bg-success/20 text-success border-success/30',
-        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
-        'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
-    
-    const dataPreview = JSON.stringify(log.data).substring(0, 150);
-    const dataFull = JSON.stringify(log.data, null, 2);
-    const isTruncated = dataFull.length > 150;
-    
-    return `
-        <tr class="hover:bg-surfaceHover transition-colors">
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[120px]">${escapeHtml(log.id)}</td>
-            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4">
-                <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
-                    ${log.operation}
-                </span>
-            </td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
-            <td class="px-6 py-4 text-xs">
-                <details class="group">
-                    <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
-                        ${escapeHtml(dataPreview)}${isTruncated ? '...' : ''}
-                    </summary>
-                    <div class="mt-2 relative">
-                        <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto max-w-md text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
-                        <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-                            </svg>
-                        </button>
-                    </div>
-                </details>
-            </td>
-        </tr>
-    `;
-}
-
-function renderMobileCard(log) {
-    const opStyle = {
-        'INSERT': 'bg-success/20 text-success border-success/30',
-        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
-        'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
-    
-    const dataFull = JSON.stringify(log.data, null, 2);
-    
-    return `
-        <div class="p-4 border-b border-border">
-            <div class="flex items-start justify-between gap-2">
-                <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-2">
-                        <span class="font-medium text-text truncate">${escapeHtml(log.table_name)}</span>
-                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full border ${opStyle}">
-                            ${log.operation}
-                        </span>
-                    </div>
-                    <div class="text-xs text-textMuted">
-                        ID: ${escapeHtml(log.id)}
-                        <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
-                    </div>
-                    <div class="text-xs text-textMuted mt-1">
-                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
-                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
-                    </div>
-                    <details class="group mt-2">
-                        <summary class="cursor-pointer text-primary hover:text-primaryHover text-xs list-none flex items-center gap-1">
-                            <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-                            </svg>
-                            View Data
-                        </summary>
-                        <div class="mt-2 relative">
-                            <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
-                            <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-                                </svg>
-                            </button>
-                        </div>
-                    </details>
-                </div>
-            </div>
-        </div>
-    `;
-}
-
 // Toggle filters on mobile
 function toggleFilters() {
     filtersExpanded = !filtersExpanded;
@@ -416,6 +301,130 @@ function loadLogs() {
                 </div>
             `;
         });
+}
+
+function renderDesktopRow(log) {
+    const opStyle = {
+        'INSERT': 'bg-success/20 text-success border-success/30',
+        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
+        'DELETE': 'bg-error/20 text-error border-error/30'
+    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    
+    const dataPreview = JSON.stringify(log.data).substring(0, 150);
+    const dataFull = JSON.stringify(log.data, null, 2);
+    const isTruncated = dataFull.length > 150;
+    
+    return `
+        <tr class="hover:bg-surfaceHover transition-colors">
+            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[120px]">${escapeHtml(log.id)}</td>
+            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
+            <td class="px-6 py-4">
+                <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
+                    ${log.operation}
+                </span>
+            </td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
+            <td class="px-6 py-4 text-xs">
+                <details class="group">
+                    <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
+                        ${escapeHtml(dataPreview)}${isTruncated ? '...' : ''}
+                    </summary>
+                    <div class="mt-2 relative">
+                        <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto max-w-md text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
+                        <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                            </svg>
+                        </button>
+                    </div>
+                </details>
+            </td>
+        </tr>
+    `;
+}
+
+function renderMobileCard(log) {
+    const opStyle = {
+        'INSERT': 'bg-success/20 text-success border-success/30',
+        'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
+        'DELETE': 'bg-error/20 text-error border-error/30'
+    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    
+    const dataFull = JSON.stringify(log.data, null, 2);
+    
+    return `
+        <div class="p-4 hover:bg-surfaceHover transition-colors">
+            <div class="flex items-start justify-between gap-3 mb-3">
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-2">
+                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full border ${opStyle}">
+                            ${log.operation}
+                        </span>
+                        <span class="font-medium text-text truncate">${escapeHtml(log.table_name)}</span>
+                    </div>
+                    <div class="flex items-center gap-2 text-xs text-textMuted">
+                        <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
+                    </div>
+                    <div class="flex flex-col gap-1 mt-2 text-xs">
+                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
+                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
+                    </div>
+                </div>
+            </div>
+            <details class="group">
+                <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors text-sm list-none flex items-center gap-2">
+                    <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    View Data
+                </summary>
+                <div class="mt-2 relative">
+                    <pre class="p-3 bg-surfaceHover rounded-lg text-xs overflow-auto text-text border border-border"><code>${escapeHtml(dataFull)}</code></pre>
+                    <button onclick="copyJson(this)" class="absolute top-2 right-2 p-1.5 bg-surfaceHover hover:bg-border rounded text-textMuted hover:text-text transition-colors" aria-label="Copy JSON">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                        </svg>
+                    </button>
+                </div>
+            </details>
+        </div>
+    `;
+}
+
+function formatLocalTime(timeStr) {
+    if (!timeStr) return '-';
+    try {
+        const date = new Date(timeStr);
+        return date.toLocaleString();
+    } catch {
+        return timeStr;
+    }
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function copyJson(button) {
+    const code = button.parentElement.querySelector('code');
+    if (code) {
+        navigator.clipboard.writeText(code.textContent).then(() => {
+            // Show feedback
+            const originalHtml = button.innerHTML;
+            button.innerHTML = `
+                <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                </svg>
+            `;
+            setTimeout(() => {
+                button.innerHTML = originalHtml;
+            }, 2000);
+        });
+    }
 }
 
 // Initial load

--- a/api/server.go
+++ b/api/server.go
@@ -51,9 +51,18 @@ type Server struct {
 	configWatcher *config.Watcher
 	sinksRoot   *os.Root // Secure root for sinks directory access
 	skillsPath  string // Path to SQL skills directory from config
+	timezone    *time.Location // Timezone for time formatting (from mssql.timezone config)
 }
 
 // NewServer creates a new API server
+// formatTime formats a time.Time to the configured timezone string
+func (s *Server) formatTime(t time.Time) string {
+	if s.timezone == nil || s.timezone == time.UTC {
+		return t.Format("2006-01-02T15:04:05.999Z")
+	}
+	return t.In(s.timezone).Format("2006-01-02 15:04:05")
+}
+
 func NewServer(manager *plugin.Manager, port int) *Server {
 	return &Server{
 		manager: manager,
@@ -78,6 +87,9 @@ func NewServerWithCDC(manager *plugin.Manager, dlqStore *dlq.DLQ, cdcAdmin *cdca
 		skillsPath = "./skills/sql"
 	}
 	
+	// Parse timezone from MSSQL config for time formatting
+	tz := config.ParseTimezone(cfg.MSSQL.Timezone)
+	
 	return &Server{
 		manager:       manager,
 		dlq:           dlqStore,
@@ -88,6 +100,7 @@ func NewServerWithCDC(manager *plugin.Manager, dlqStore *dlq.DLQ, cdcAdmin *cdca
 		config:        cfg,
 		configWatcher: watcher,
 		skillsPath:    skillsPath,
+		timezone:      tz,
 	}
 }
 
@@ -685,7 +698,7 @@ func (s *Server) handleCDCGap(c *xun.Context) error {
 			"lag_duration_secs": int64(gapInfo.LagDuration.Seconds()),
 			"status":            status,
 			"status_color":      statusColor,
-			"checked_at":        gapInfo.CheckedAt,
+			"checked_at":        s.formatTime(gapInfo.CheckedAt),
 		})
 	}
 
@@ -927,14 +940,9 @@ func (s *Server) collectOverviewMetrics() OverviewMetrics {
 			metrics.CDCStatus = "active"
 			metrics.CDCMessage = "CDC polling active"
 			
-			// Get last sync time (stored as string in DB)
+			// Get last sync time (already formatted by store)
 			if lastPollStr, ok := state["last_poll_time"].(string); ok && lastPollStr != "" {
-				// Parse the timestamp string and format for display
-				if lastPoll, err := time.Parse("2006-01-02 15:04:05.999999999", lastPollStr); err == nil {
-					metrics.LastSyncTime = lastPoll.Format("2006-01-02 15:04:05")
-				} else {
-					metrics.LastSyncTime = lastPollStr
-				}
+				metrics.LastSyncTime = lastPollStr
 			}
 			
 			// Count tracked tables
@@ -1082,7 +1090,7 @@ func (s *Server) handleSinksList(c *xun.Context) error {
 				sink["exists"] = true
 				sink["size"] = info.Size()
 				sink["sizeHuman"] = formatFileSize(info.Size())
-				sink["modTime"] = info.ModTime().Format(time.RFC3339)
+				sink["modTime"] = s.formatTime(info.ModTime())
 			} else {
 				sink["exists"] = false
 				sink["sizeHuman"] = "N/A"

--- a/api/server.go
+++ b/api/server.go
@@ -54,8 +54,10 @@ type Server struct {
 	timezone    *time.Location // Timezone for time formatting (from mssql.timezone config)
 }
 
-// NewServer creates a new API server
-// formatTime formats a time.Time to the configured timezone string
+// formatTime formats a time.Time to the configured timezone string.
+// If timezone is nil or UTC, formats as UTC: "2006-01-02T15:04:05.999Z".
+// Otherwise, converts to the configured timezone and formats as local time: "2006-01-02 15:04:05".
+// Note: time.Local is NOT treated specially; only nil and time.UTC use UTC format.
 func (s *Server) formatTime(t time.Time) string {
 	if s.timezone == nil || s.timezone == time.UTC {
 		return t.Format("2006-01-02T15:04:05.999Z")

--- a/app/sqlite/sqlite.go
+++ b/app/sqlite/sqlite.go
@@ -414,9 +414,10 @@ func (s *Store) GetChanges(limit int) ([]map[string]interface{}, error) {
 	return s.GetChangesWithFilter(limit, "", "", "")
 }
 
-// formatTimeInTimezone converts a time value to the configured timezone string
-// If timezone is nil or time.Local, returns as-is (UTC)
-// Otherwise, converts to the configured timezone and formats as local time
+// formatTimeInTimezone converts a time value to the configured timezone string.
+// If timezone is nil or UTC, formats as UTC: "2006-01-02T15:04:05.999Z".
+// Otherwise, converts to the configured timezone and formats as local time: "2006-01-02 15:04:05".
+// Note: time.Local is NOT treated specially; only nil and time.UTC use UTC format.
 func (s *Store) formatTimeInTimezone(t interface{}) interface{} {
 	if t == nil {
 		return nil

--- a/app/sqlite/sqlite.go
+++ b/app/sqlite/sqlite.go
@@ -18,12 +18,18 @@ import (
 
 // Store implements core.Store for SQLite
 type Store struct {
-	db   *sql.DB
-	path string
+	db       *sql.DB
+	path     string
+	timezone *time.Location // Timezone for API time formatting (from mssql.timezone config)
 }
 
 // NewStore creates a new SQLite store with WAL mode and optimized settings
 func NewStore(path string) (*Store, error) {
+	return NewStoreWithTimezone(path, nil)
+}
+
+// NewStoreWithTimezone creates a new SQLite store with optional timezone for API formatting
+func NewStoreWithTimezone(path string, timezone *time.Location) (*Store, error) {
 	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, fmt.Errorf("create directory: %w", err)
@@ -59,7 +65,7 @@ func NewStore(path string) (*Store, error) {
 		return nil, fmt.Errorf("create tables: %w", err)
 	}
 
-	store := &Store{db: db, path: path}
+	store := &Store{db: db, path: path, timezone: timezone}
 	// Initialize poller state
 	if err := store.initPollerState(); err != nil {
 		if closeErr := db.Close(); closeErr != nil {
@@ -142,7 +148,7 @@ func (s *Store) GetPollerState() (map[string]interface{}, error) {
 	}
 
 	if lastPollTime.Valid {
-		state["last_poll_time"] = lastPollTime.String
+		state["last_poll_time"] = s.formatTimeInTimezone(lastPollTime.String)
 	} else {
 		state["last_poll_time"] = nil
 	}
@@ -154,7 +160,7 @@ func (s *Store) GetPollerState() (map[string]interface{}, error) {
 	}
 
 	if updatedAt.Valid {
-		state["updated_at"] = updatedAt.String
+		state["updated_at"] = s.formatTimeInTimezone(updatedAt.String)
 	} else {
 		state["updated_at"] = nil
 	}
@@ -408,6 +414,44 @@ func (s *Store) GetChanges(limit int) ([]map[string]interface{}, error) {
 	return s.GetChangesWithFilter(limit, "", "", "")
 }
 
+// formatTimeInTimezone converts a time value to the configured timezone string
+// If timezone is nil or time.Local, returns as-is (UTC)
+// Otherwise, converts to the configured timezone and formats as local time
+func (s *Store) formatTimeInTimezone(t interface{}) interface{} {
+	if t == nil {
+		return nil
+	}
+
+	// Parse the time value
+	var parsedTime time.Time
+	var err error
+
+	switch v := t.(type) {
+	case time.Time:
+		parsedTime = v
+	case string:
+		// Try RFC3339Nano first, then other formats
+		parsedTime, err = time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999-07:00", v)
+			if err != nil {
+				return t // Return as-is if cannot parse
+			}
+		}
+	default:
+		return t
+	}
+
+	// If no timezone configured or UTC, return formatted UTC string
+	if s.timezone == nil || s.timezone == time.UTC {
+		return parsedTime.Format("2006-01-02T15:04:05.999Z")
+	}
+
+	// Convert to configured timezone and format
+	localTime := parsedTime.In(s.timezone)
+	return localTime.Format("2006-01-02 15:04:05")
+}
+
 // GetChangesWithFilter retrieves changes with optional filters
 func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID string) ([]map[string]interface{}, error) {
 	query := `SELECT id, transaction_id, table_name, operation, data, changed_at, pulled_at FROM transactions WHERE 1=1`
@@ -463,8 +507,8 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 			"table_name":     resultTableName,
 			"operation":      resultOperation,
 			"data":           data,
-			"changed_at":     cdcTime,
-			"pulled_at":      pulledAt,
+			"changed_at":     s.formatTimeInTimezone(cdcTime),
+			"pulled_at":      s.formatTimeInTimezone(pulledAt),
 		})
 	}
 

--- a/cmd/dbkrab/main.go
+++ b/cmd/dbkrab/main.go
@@ -100,7 +100,9 @@ func main() {
 	var store *app.Store
 	switch cfg.App.Type {
 	case "sqlite":
-		store, err = app.NewStore(cfg.App.Path)
+		// Parse timezone from MSSQL config for API time formatting
+		apiTimezone := config.ParseTimezone(cfg.MSSQL.Timezone)
+		store, err = app.NewStoreWithTimezone(cfg.App.Path, apiTimezone)
 		if err != nil {
 			slog.Error("failed to create SQLite store", "error", err)
 			os.Exit(1)
@@ -110,7 +112,7 @@ func main() {
 				slog.Warn("store.Close error", "error", err)
 			}
 		}()
-		slog.Info("SQLite store initialized", "path", cfg.App.Path)
+		slog.Info("SQLite store initialized", "path", cfg.App.Path, "timezone", apiTimezone.String())
 	default:
 		slog.Error("unknown store type", "type", cfg.App.Type)
 		os.Exit(1)


### PR DESCRIPTION
## 功能描述

API 返回的时间根据 `mssql.timezone` 配置进行格式化，统一界面时间显示。

## 修改内容

### app/sqlite/sqlite.go
- Store 结构体添加 `timezone` 字段
- 新增 `NewStoreWithTimezone` 函数
- 新增 `formatTimeInTimezone` 方法，统一格式化时间
- `GetChangesWithFilter` 和 `GetPollerState` 使用配置时区格式化时间

### api/server.go
- Server 结构体添加 `timezone` 字段
- 新增 `formatTime` 方法，统一格式化 `time.Time` 类型
- `checked_at` 和 `modTime` 使用配置时区格式化

### cmd/dbkrab/main.go
- 传递 `mssql.timezone` 到 store 和 server

## 时间格式规则

| 配置 | 格式示例 |
|------|---------|
| `timezone: Asia/Shanghai` | `2026-04-10 10:32:45` |
| 未配置或 UTC | `2026-04-10T02:32:45.123Z` |

## 影响的 API

- `/api/cdc/logs` - `changed_at`, `pulled_at`
- `/api/cdc/status` - `last_poll_time`, `updated_at`
- `/api/cdc/gap` - `checked_at`

## Summary by Sourcery

Format API-exposed timestamps according to the configured MSSQL timezone and align dashboard display with localized time.

New Features:
- Add configurable timezone-aware formatting for CDC-related timestamps returned from the SQLite store and API server.

Enhancements:
- Introduce a centralized time formatting helper in the SQLite store and API server and wire it to the MSSQL timezone config in the CLI entrypoint.
- Improve the CDC logs dashboard to format timestamps in the browser and enhance mobile/desktop log rendering with reusable helpers and JSON copy support.