### PR TITLE
fix(poller): use per-table LSN offsets instead of global minimum

### DIFF
--- a/internal/core/poller.go
+++ b/internal/core/poller.go
@@ -481,45 +481,58 @@ func (p *Poller) processDirect(ctx context.Context, allChanges []Change, results
 }
 
 // updateOffsets updates offset checkpoints for successfully polled tables
+// Each table maintains its own independent LSN offset.
+// Only tables with changes have their offsets advanced.
+// Tables with no changes keep their existing offset.
 func (p *Poller) updateOffsets(results []tablePollResult, allChanges []Change, fetchTime time.Time, syncDuration time.Duration, storeDuration time.Duration, dlqCount int, txCount int) error {
-	// Build set of successfully polled tables
-	successfulTables := make(map[string]bool)
+	// Track the maximum LSN across all tables for observability/metrics
+	var maxLSN LSN
+	tablesUpdated := 0
+
+	// Update each table's offset independently based on its own lastLSN
 	for _, r := range results {
-		if r.err == nil {
-			successfulTables[r.table] = true
+		if r.err != nil {
+			// Table had an error - don't update its offset
+			slog.Warn("skipping offset update for table with error",
+				"table", r.table,
+				"error", r.err)
+			continue
 		}
+
+		if len(r.changes) == 0 {
+			// No changes for this table - keep existing offset, don't block others
+			slog.Debug("no changes for table, keeping existing offset", "table", r.table)
+			continue
+		}
+
+		// Table has changes - advance its offset to its own lastLSN
+		if err := p.offsets.Set(r.table, r.lastLSN.String()); err != nil {
+			slog.Error("failed to save offset", "table", r.table, "error", err)
+			continue
+		}
+		tablesUpdated++
+
+		// Track max LSN for observability
+		if maxLSN.IsZero() || r.lastLSN.Compare(maxLSN) > 0 {
+			maxLSN = r.lastLSN
+		}
+
+		slog.Debug("advanced table offset",
+			"table", r.table,
+			"lsn", r.lastLSN.String(),
+			"changes", len(r.changes))
 	}
 
-	// Find minimum lastLSN across all tables that had changes
-	var validResults []tablePollResult
-	for _, r := range results {
-		if r.err == nil && len(r.changes) > 0 {
-			validResults = append(validResults, r)
-		}
+	if tablesUpdated > 0 {
+		slog.Info("advanced offsets for tables",
+			"tables_updated", tablesUpdated,
+			"max_lsn", maxLSN.String())
 	}
 
-	// Update poller state in store for observability (even if no changes)
-	var lastLSN string
-	if len(validResults) > 0 {
-		minLSN := validResults[0].lastLSN
-		for _, r := range validResults[1:] {
-			if r.lastLSN.Compare(minLSN) < 0 {
-				minLSN = r.lastLSN
-			}
-		}
-
-		// Only advance offsets for successfully polled tables
-		for table := range successfulTables {
-			if err := p.offsets.Set(table, minLSN.String()); err != nil {
-				slog.Error("failed to save offset", "table", table, "error", err)
-			}
-		}
-
-		slog.Info("advanced global checkpoint",
-			"lsn", minLSN.String(),
-			"tables", len(successfulTables))
-
-		lastLSN = minLSN.String()
+	// Use max LSN for observability state (not for checkpointing)
+	lastLSN := ""
+	if !maxLSN.IsZero() {
+		lastLSN = maxLSN.String()
 	}
 
 	// Always update poller state for observability


### PR DESCRIPTION
Fixes: #115

## What Changed
Replaced global minimum LSN calculation with independent per-table offset tracking in `internal/core/poller.go`. Each monitored table now maintains and advances its own LSN offset independently.

## Why It Changed
The global minimum LSN approach caused a critical bug where inactive or stale tables blocked offset progression for all tables. This resulted in:
- Same CDC changes being repeatedly processed every poll cycle
- ~5300x data duplication (2.58M records for 489 actual changes)
- Offsets stuck at stale values despite processing higher LSNs

The root cause: `updateOffsets` calculated `minLSN` across all tables, so if Table B had no changes (stale LSN), it blocked Table A from advancing even after processing changes.

## How to Test
1. Configure multiple CDC tables with varying activity levels
2. Verify active tables advance their offsets independently when others are inactive
3. Confirm no duplicate processing - check transactions table for unique change events only
4. Monitor offset values advancing correctly per table
5. Test adding/removing tables without affecting other table offsets

## Summary by Sourcery

Track and persist per-table LSN offsets instead of using a global minimum checkpoint when updating poller offsets.

Bug Fixes:
- Prevent inactive or errored tables from blocking LSN offset advancement for active tables by skipping their offset updates.
- Avoid repeated processing of the same CDC changes by advancing offsets only for tables that actually have new changes.

Enhancements:
- Improve logging and observability by recording per-table offset advancements and tracking the maximum LSN across polled tables for metrics.