### PR TITLE
feat: add CDC LSN to transactions and show on logs page

### DIFF
--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -115,6 +115,7 @@
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Table</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Operation</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Transaction ID</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">LSN <span class="text-[10px] normal-case">(tx-level)</span></th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Changed At</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Pulled At</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Data</th>
@@ -122,7 +123,7 @@
                 </thead>
                 <tbody class="divide-y divide-border" id="logs-container-desktop">
                     <tr>
-                        <td colspan="6" class="px-6 py-8 text-center text-textMuted">
+                        <td colspan="8" class="px-6 py-8 text-center text-textMuted">
                             <div class="flex items-center justify-center gap-2">
                                 <svg class="animate-spin h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24">
                                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -200,6 +201,7 @@ function renderDesktopRow(log) {
                 </span>
             </td>
             <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono text-[10px] truncate max-w-[180px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</td>
             <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
             <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
             <td class="px-6 py-4 text-xs">
@@ -241,8 +243,9 @@ function renderMobileCard(log) {
                         </span>
                     </div>
                     <div class="text-xs text-textMuted">
-                        ID: ${escapeHtml(log.id)}
-                        <span class="truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span>
+                        ID: ${escapeHtml(log.id)}<br>
+                        TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
+                        LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>
                     <div class="text-xs text-textMuted mt-1">
                         <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,23 @@ CDC data is injected as SQL parameters:
 | `@cdc_operation` | Operation type (1=DELETE, 2=INSERT, 4=UPDATE) |
 | `@{table}_{field}` | Data field value (e.g., `@orders_order_id`) |
 
+### Transactions Table (SQLite)
+
+The `transactions` table stores captured CDC changes:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER | Local autoincrement ID |
+| `transaction_id` | TEXT | MSSQL transaction ID (GUID) |
+| `table_name` | TEXT | Source table name |
+| `operation` | TEXT | Operation type (INSERT/DELETE/UPDATE_AFTER) |
+| `data` | TEXT | JSON-encoded row data |
+| `lsn` | TEXT | CDC LSN as hex string (e.g., `0x0000002D00000A760066`), nullable |
+| `changed_at` | TIMESTAMP | Transaction commit time from MSSQL |
+| `pulled_at` | TIMESTAMP | When the change was pulled |
+
+**LSN Semantics**: LSN (Log Sequence Number) is a transaction-level identifier from MSSQL CDC. Multiple row changes in the same transaction share the same LSN. Stored as a `0x`-prefixed hex string for readability and deterministic sorting.
+
 ### Sinks
 
 | | Sinks |

--- a/internal/store/sqlite/migrations/002_add_lsn/001_add_lsn_to_transactions.sql
+++ b/internal/store/sqlite/migrations/002_add_lsn/001_add_lsn_to_transactions.sql
@@ -1,0 +1,9 @@
+-- Migration: 002_add_lsn_to_transactions
+-- Description: Add LSN (Log Sequence Number) column to transactions table for CDC correlation
+-- LSN is stored as a hex string prefixed with '0x' for readability (e.g., 0x0000002D00000A760066)
+-- Note: LSN is transaction-level, not row-level. Multiple rows in the same transaction share the same LSN.
+
+ALTER TABLE transactions ADD COLUMN lsn TEXT;
+
+-- Index for LSN range queries (useful for correlating changes by transaction)
+CREATE INDEX IF NOT EXISTS idx_lsn ON transactions(lsn);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -33,6 +33,7 @@ func NewStore(db *sqlite.DB) (*Store, error) {
 			table_name TEXT NOT NULL,
 			operation TEXT NOT NULL,
 			data TEXT,
+			lsn TEXT,
 			changed_at TIMESTAMP,
 			pulled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		)
@@ -58,6 +59,10 @@ func NewStore(db *sqlite.DB) (*Store, error) {
 	if err := db.Flush(); err != nil {
 		return nil, fmt.Errorf("commit DDL: %w", err)
 	}
+
+	// Add lsn column if it doesn't exist (for existing databases created before this migration)
+	_, _ = db.Exec(`ALTER TABLE transactions ADD COLUMN lsn TEXT`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_lsn ON transactions(lsn)`)
 
 	// Initialize poller state (INSERT OR IGNORE is idempotent)
 	if err := s.initPollerState(); err != nil {
@@ -153,8 +158,8 @@ func (s *Store) Write(tx *core.Transaction) error {
 	}()
 
 	stmt, err := sqlTx.Prepare(`
-		INSERT INTO transactions (transaction_id, table_name, operation, data, changed_at, pulled_at)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO transactions (transaction_id, table_name, operation, data, lsn, changed_at, pulled_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
@@ -176,11 +181,18 @@ func (s *Store) Write(tx *core.Transaction) error {
 			cdcTime = change.CommitTime // Already converted to UTC in CDC query layer
 		}
 
+		// Convert LSN bytes to hex string with 0x prefix for readability and deterministic sorting
+		var lsnStr string
+		if len(change.LSN) > 0 {
+			lsnStr = "0x" + hex.EncodeToString(change.LSN)
+		}
+
 		_, err = stmt.Exec(
 			tx.ID,
 			change.Table,
 			change.Operation.String(),
 			string(dataJSON),
+			lsnStr,
 			cdcTime,
 			time.Now().UTC(), // pulled_at - store in UTC for consistency
 		)
@@ -246,7 +258,7 @@ func (s *Store) GetChanges(limit int) ([]map[string]interface{}, error) {
 
 // GetChangesWithFilter retrieves changes with optional filters
 func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID string) ([]map[string]interface{}, error) {
-	query := `SELECT id, transaction_id, table_name, operation, data, changed_at, pulled_at FROM transactions WHERE 1=1`
+	query := `SELECT id, transaction_id, table_name, operation, data, lsn, changed_at, pulled_at FROM transactions WHERE 1=1`
 	args := []interface{}{}
 
 	if tableName != "" {
@@ -281,10 +293,10 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 	var results []map[string]interface{}
 	for rows.Next() {
 		var id int
-		var resultTxID, resultTableName, resultOperation, dataStr string
+		var resultTxID, resultTableName, resultOperation, dataStr, lsnStr string
 		var cdcTime, pulledAt interface{}
 
-		if err := rows.Scan(&id, &resultTxID, &resultTableName, &resultOperation, &dataStr, &cdcTime, &pulledAt); err != nil {
+		if err := rows.Scan(&id, &resultTxID, &resultTableName, &resultOperation, &dataStr, &lsnStr, &cdcTime, &pulledAt); err != nil {
 			return nil, err
 		}
 
@@ -299,6 +311,7 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 			"table_name":     resultTableName,
 			"operation":      resultOperation,
 			"data":           data,
+			"lsn":            lsnStr,
 			"changed_at":     cdcTime,
 			"pulled_at":      pulledAt,
 		})


### PR DESCRIPTION
Fixes: #117

What changed:
- Database migration adds a nullable lsn TEXT column to the transactions table.
- CDC polling now captures the __$start_lsn value, converts the raw []byte to a stable hex string (prefixed with 0x), and persists it with each change record.
- Internal models and API responses include an lsn string field.
- SQLite insert logic updated to save lsn for captured changes.
- Frontend logs page adds an LSN column and clarifies that LSN is transaction-level and may be identical for multiple rows.
- Tests and documentation updated to cover persistence, API exposure, and frontend display.

Why it changed:
Operators need a transaction-level identifier from MSSQL CDC to correlate multiple row changes that belong to the same transaction. Persisting and surfacing LSNs (as human-friendly hex strings) enables easier debugging and correlation across systems.

How to test:
1. Apply the migration and verify the transactions table contains an lsn TEXT column.
2. Run the CDC agent against MSSQL and perform a multi-row transaction; verify the inserted change records in SQLite have an lsn value (e.g. 0x0000002D00000A760066) and that rows from the same transaction share the same LSN.
3. Call the logs API endpoints and confirm responses include the lsn field with the hex string.
4. Open the Logs UI and confirm the new LSN column displays values and notes the transaction-level semantics.
5. Run the added unit/integration tests that validate LSN conversion, persistence, and API exposure.

Notes: LSN is stored as a hex string for readability and deterministic sorting. Related commit: 6bb8552 (fix(sqlite): add LSN column to transactions and expose it in change logs).

## Summary by Sourcery

Add support for persisting and exposing CDC transaction LSNs in the SQLite store and change retrieval APIs.

New Features:
- Store transaction-level CDC LSN values in the transactions table as hex strings and expose them via change retrieval APIs.

Enhancements:
- Introduce a SQLite migration and backward-compatible schema initialization to add an indexed LSN column for correlating changes by transaction.