### PR TITLE
fix: add TPS card to Overview with 10s refresh and compact mobile

### DIFF
--- a/api/dashboard/pages/index.html
+++ b/api/dashboard/pages/index.html
@@ -6,10 +6,10 @@
     <!-- Overview Dashboard - loaded via HTMX with auto-refresh -->
     <div id="overview-container" 
          hx-get="/api/overview" 
-         hx-trigger="load every 30s"
+         hx-trigger="load every 10s"
          hx-swap="innerHTML">
         <!-- Initial loading state -->
-        <div class="space-y-6">
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             <!-- Health Status Card -->
             <div class="bg-surface rounded-xl shadow-lg p-6 border border-border">
                 <div class="flex items-center gap-4">

--- a/api/server.go
+++ b/api/server.go
@@ -874,9 +874,9 @@ func renderOverviewHTML(m OverviewMetrics) string {
 	sb.WriteString(`</div></div></div>`)
 	
 	// TPS Monitoring Card
-	sb.WriteString(`<div class="bg-surface rounded-xl shadow-lg p-6 border border-border">`)
+	sb.WriteString(`<div class="bg-surface rounded-xl shadow-lg p-6 border border-border hover:border-border/60 transition-all">`)
 	sb.WriteString(`<h3 class="text-lg font-semibold text-text mb-4">TPS Monitoring</h3>`)
-	sb.WriteString(`<div class="grid grid-cols-2 sm:grid-cols-5 gap-4">`)
+	sb.WriteString(`<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">`)
 	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Current TPS</p><p class="text-xl font-bold text-primary">%.1f</p></div>`, m.LastSyncTPS)
 	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Avg TPS (1m)</p><p class="text-xl font-bold text-success">%.1f</p></div>`, m.AvgTPS1m)
 	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Last Duration</p><p class="text-xl font-bold text-text">%d ms</p></div>`, m.LastSyncDurationMs)

--- a/api/server.go
+++ b/api/server.go
@@ -873,6 +873,21 @@ func renderOverviewHTML(m OverviewMetrics) string {
 	}
 	sb.WriteString(`</div></div></div>`)
 	
+	// TPS Monitoring Card
+	sb.WriteString(`<div class="bg-surface rounded-xl shadow-lg p-6 border border-border">`)
+	sb.WriteString(`<h3 class="text-lg font-semibold text-text mb-4">TPS Monitoring</h3>`)
+	sb.WriteString(`<div class="grid grid-cols-2 sm:grid-cols-5 gap-4">`)
+	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Current TPS</p><p class="text-xl font-bold text-primary">%.1f</p></div>`, m.LastSyncTPS)
+	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Avg TPS (1m)</p><p class="text-xl font-bold text-success">%.1f</p></div>`, m.AvgTPS1m)
+	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Last Duration</p><p class="text-xl font-bold text-text">%d ms</p></div>`, m.LastSyncDurationMs)
+	fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">DLQ Count</p><p class="text-xl font-bold text-error">%d</p></div>`, m.LastDLQCount)
+	if m.LastPollTime != "" {
+		fmt.Fprintf(&sb, `<div><p class="text-textMuted text-sm">Last Poll</p><p class="text-sm font-medium text-text"><span class="local-time" data-utc="%s">%s</span></p></div>`, m.LastPollTime, m.LastPollTime)
+	} else {
+		sb.WriteString(`<div><p class="text-textMuted text-sm">Last Poll</p><p class="text-sm font-medium text-textMuted">N/A</p></div>`)
+	}
+	sb.WriteString(`</div></div>`)
+
 	// DLQ Stats Cards
 	sb.WriteString(`<div class="grid grid-cols-1 sm:grid-cols-3 gap-4 md:gap-6">`)
 	sb.WriteString(`<div class="bg-surface rounded-xl shadow-lg p-6 border border-error/20 hover:border-error/40 transition-all">`)
@@ -947,6 +962,13 @@ type OverviewMetrics struct {
 	// System Info
 	Uptime string
 	LastSyncTime string
+
+	// TPS Monitoring (from Poller.GetMetrics)
+	LastSyncTPS       float64
+	AvgTPS1m          float64
+	LastSyncDurationMs int64
+	LastDLQCount      int64
+	LastPollTime      string
 }
 
 // collectOverviewMetrics collects all metrics for the dashboard overview
@@ -1096,7 +1118,27 @@ func (s *Server) collectOverviewMetrics() OverviewMetrics {
 			}
 		}
 	}
-	
+
+	// Collect TPS metrics from metrics provider
+	if s.metricsProvider != nil {
+		m := s.metricsProvider.GetMetrics()
+		if v, ok := m["last_sync_tps"].(float64); ok {
+			metrics.LastSyncTPS = v
+		}
+		if v, ok := m["avg_tps_1m"].(float64); ok {
+			metrics.AvgTPS1m = v
+		}
+		if v, ok := m["last_sync_duration_ms"].(int64); ok {
+			metrics.LastSyncDurationMs = v
+		}
+		if v, ok := m["last_dlq_count"].(int64); ok {
+			metrics.LastDLQCount = v
+		}
+		if v, ok := m["last_poll_time"].(string); ok && v != "" {
+			metrics.LastPollTime = v
+		}
+	}
+
 	return metrics
 }
 


### PR DESCRIPTION
Fixes: #118

What changed:
- collectOverviewMetrics() (api/server.go) now includes TPS-related metrics from metricsProvider.GetMetrics(): last_sync_tps, avg_tps_1m, last_sync_duration_ms, last_dlq_count, last_poll_time.
- renderOverviewHTML() (api/server.go) now renders a TPS monitoring card showing Current TPS, 1-minute avg TPS, last sync duration (ms), DLQ count, and last poll time.
- Overview HTMX refresh interval updated to 10s (api/dashboard/pages/index.html: hx-trigger="load every 10s").
- Overview grid layout updated to a more compact responsive layout: mobile grid-cols-2, md:grid-cols-3, lg:grid-cols-4.

Why it changed:
- Surface real-time TPS metrics on the Overview dashboard and improve mobile density for better UX. The implementation is minimal and reuses the existing metricsProvider without adding new endpoints.

How to test:
1. Start the server and open the Overview dashboard.
2. Confirm a TPS card appears listing Current TPS, 1m avg TPS, last sync duration (ms), DLQ count, and last poll time.
3. Inspect the /api/overview response and verify it includes last_sync_tps, avg_tps_1m, last_sync_duration_ms, last_dlq_count, and last_poll_time.
4. Observe the TPS card updates approximately every 10 seconds (HTMX refresh).
5. Resize the browser or use device emulation: on small widths cards should render in 2 columns and expand to md/lg columns as specified.

Notes: Changes are limited to api/server.go and api/dashboard/pages/index.html; no new services or endpoints were introduced.

## Summary by Sourcery

Surface TPS monitoring metrics on the Overview dashboard and adjust its layout and refresh behavior.

New Features:
- Add a TPS monitoring card to the Overview dashboard displaying current TPS, 1-minute average TPS, last sync duration, DLQ count, and last poll time.

Enhancements:
- Extend overview metrics collection to include TPS-related values from the existing metrics provider.
- Tighten the Overview dashboard auto-refresh interval from 30s to 10s for more timely metric updates.
- Make the Overview initial layout more compact and responsive with a multi-column grid on mobile and larger screens.