### PR TITLE
fix: make reset clear unified DB and logs under /opt/dbkrab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,16 +141,17 @@ stop:
 ## restart: Restart dbkrab
 restart: stop deploy
 
-## reset: Reset CDC state (delete offset/cdc.db) and restart dbkrab
+## reset: Reset dbkrab state (clear DB and logs under /opt/dbkrab) and restart
 reset:
-	@echo "Resetting CDC state..."
+	@echo "Resetting dbkrab state..."
 	@echo "Stopping dbkrab..."
 	@pkill -x dbkrab 2>/dev/null || true
 	@sleep 2
-	@echo "Deleting offset.db and cdc.db..."
-	@rm -f /opt/dbkrab/data/app/offset.db /opt/dbkrab/data/app/offset.db-wal /opt/dbkrab/data/app/offset.db-shm
-	@rm -f /opt/dbkrab/data/app/cdc.db /opt/dbkrab/data/app/cdc.db-wal /opt/dbkrab/data/app/cdc.db-shm
-	@echo "✅ CDC state reset"
+	@echo "Deleting app data files..."
+	@rm -rf /opt/dbkrab/data/app/*
+	@echo "Deleting logs..."
+	@rm -rf /opt/dbkrab/logs/*
+	@mkdir -p /opt/dbkrab/logs
 	@echo "Starting dbkrab..."
 	@cd /opt/dbkrab && nohup ./dbkrab --config config.yaml > logs/dbkrab.log 2>&1 &
 	@sleep 3


### PR DESCRIPTION
Fixes: #127

What changed:
- Updated the Makefile `reset` target to operate under the agreed root /opt/dbkrab.
- `make reset` now stops the dbkrab process (pkill -x dbkrab || true), waits briefly, and removes all runtime DB artifacts under /opt/dbkrab/data/app/* and all logs under /opt/dbkrab/logs/* using idempotent rm -rf commands.
- Ensures logs directory exists, restarts dbkrab with nohup (cd /opt/dbkrab && nohup ./dbkrab --config config.yaml > logs/dbkrab.log 2>&1 &), and verifies the process started.
- Removed references to legacy hardcoded files (offset.db, cdc.db) so cleanup matches the current layout (dbkrab.db, dlq.db and their -wal/-shm files).

Why it changed:
- The previous reset logic targeted legacy/hardcoded files and left WAL/SHM and log files behind in the new layout. A true "fresh start" requires stopping the service, removing all runtime DB artifacts and logs in /opt/dbkrab, and restarting so the service can recreate a clean state. This change aligns reset behavior with the README and deployment layout.

How to test:
1. Start dbkrab (if not running) and ensure /opt/dbkrab/data/app contains db files and /opt/dbkrab/logs contains logs.
2. Run: `make reset`.
3. Verify the dbkrab process was stopped and then restarted: `pgrep -x dbkrab` or `ps aux | grep dbkrab` should show the restarted process.
4. Verify data cleanup: `ls -A /opt/dbkrab/data/app` should show no leftover SQLite runtime files (dbkrab.db, dlq.db, *-wal, *-shm).
5. Verify logs: `ls -A /opt/dbkrab/logs` should be empty or contain only the freshly created logs/dbkrab.log after restart; `tail -n 100 /opt/dbkrab/logs/dbkrab.log` should show startup output.
6. Re-run `make reset` to confirm idempotency (no errors when files or directories are already absent).

Acceptance criteria from the issue are satisfied by these changes: stop before delete, remove unified DB and WAL/SHM files, clear/recreate logs, restart and verify, and safe to run multiple times.

## Summary by Sourcery

Align the Makefile reset target with the current /opt/dbkrab layout to fully clear dbkrab state and restart the service cleanly.

Enhancements:
- Update the reset target to remove all application data and logs under /opt/dbkrab instead of targeting legacy specific database files.
- Ensure the reset process stops dbkrab, recreates the logs directory, restarts the service, and waits briefly for it to come up.