### PR TITLE
fix(cdc): change supports_net_changes to 1 for proper UPDATE handling

### DIFF
--- a/internal/cdcadmin/admin.go
+++ b/internal/cdcadmin/admin.go
@@ -147,11 +147,13 @@ func (a *Admin) EnableCDC(schema, table string) error {
 
 	// Enable CDC for the table
 	// Note: This requires db_owner role
+	// supports_net_changes = 1 ensures UPDATE operations only return one record
+	// (operation=4 UPDATE_AFTER), not two records (operation=3 UPDATE_BEFORE and 4)
 	query := `EXEC sys.sp_cdc_enable_table 
 		@source_schema = @p1, 
 		@source_name = @p2, 
 		@role_name = NULL, 
-		@supports_net_changes = 0`
+		@supports_net_changes = 1`
 
 	_, err = db.Exec(query, schema, table)
 	if err != nil {
@@ -268,7 +270,7 @@ func (a *Admin) CheckAndEnableCDC(configuredTables []string) ([]CDCStatus, error
 					@source_schema = @schema,
 					@source_name = @table,
 					@role_name = NULL,
-					@supports_net_changes = 0
+					@supports_net_changes = 1
 			`
 			_, err = db.Exec(enableQuery, sql.Named("schema", schema), sql.Named("table", tableName))
 			if err != nil {


### PR DESCRIPTION
## Problem

Previously, CDC was enabled with `@supports_net_changes = 0` which caused UPDATE operations to return two records:
- `operation=3` (UPDATE_BEFORE) - old values before the update
- `operation=4` (UPDATE_AFTER) - new values after the update

This led to `unknown operation type: UPDATE_BEFORE` errors in the sink handler, causing data to be written to DLQ instead of the target database.

## Solution

Changed `@supports_net_changes` from `0` to `1` in both CDC enable functions:
- `EnableCDC()` in `internal/cdcadmin/admin.go`
- `CheckAndEnableCDC()` in `internal/cdcadmin/admin.go`

With `@supports_net_changes = 1`, UPDATE operations only return one record:
- `operation=4` (UPDATE_AFTER)

This is properly handled by dbkrab's existing operation handler.

## Testing

Verified on F9All database:
- Disabled all CDC tables
- Re-enabled Cost and Costitem with `supports_net_changes=1`
- CDC sync now works correctly without UPDATE_BEFORE errors
- DLQ pending count: 0

## Files Changed

- `internal/cdcadmin/admin.go`: 2 locations changed `@supports_net_changes = 0` to `1`

## Summary by Sourcery

Bug Fixes:
- Prevent CDC sink errors and DLQ writes caused by unsupported UPDATE_BEFORE records by enabling net changes for CDC-enabled tables.