### PR TITLE
fix(cdc): remove incrementLSN to prevent skipping first record

### DIFF
--- a/internal/cdc/query.go
+++ b/internal/cdc/query.go
@@ -87,27 +87,14 @@ func (q *Querier) supportsNetChanges(ctx context.Context, captureInstance string
 	return supportsNetChanges == 1, nil
 }
 
-// incrementLSN returns the next LSN value after the given LSN
-// This is essential for CDC queries to avoid fetching the same LSN repeatedly.
-// MSSQL CDC function cdc.fn_cdc_get_all_changes_* returns __$start_lsn >= @from_lsn,
-// so we must increment from_lsn before querying to get only NEW changes.
-func (q *Querier) incrementLSN(ctx context.Context, lsn []byte) ([]byte, error) {
-	var incrementedLSN []byte
-	err := q.db.QueryRowContext(ctx, "SELECT sys.fn_cdc_increment_lsn(@lsn)", sql.Named("lsn", lsn)).Scan(&incrementedLSN)
-	if err != nil {
-		return nil, fmt.Errorf("increment LSN: %w", err)
-	}
-	return incrementedLSN, nil
-}
-
 // GetChanges queries CDC changes for a table
 // captureInstance is used for MSSQL CDC queries (must include schema prefix)
 // tableName is the original table name used for returned Change.Table (without schema prefix)
 //
 // IMPORTANT: MSSQL CDC function cdc.fn_cdc_get_all_changes_* returns rows where
-// __$start_lsn >= @from_lsn. To avoid fetching the same LSN repeatedly,
-// we use sys.fn_cdc_increment_lsn() to increment the from_lsn before querying.
-// This ensures we only fetch NEW changes after the last processed LSN.
+// __$start_lsn >= @from_lsn. We query with the raw fromLSN (no increment) to include
+// the first record when starting fresh. Duplicate filtering is handled at the
+// application level (caller filters records where __$start_lsn == lastProcessedLSN).
 //
 // When supports_net_changes is enabled for the capture instance, we use
 // fn_cdc_get_net_changes_* which returns only the final row state, eliminating
@@ -149,23 +136,12 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		}
 	}
 
-	// Increment fromLSN to avoid fetching the same LSN again
-	// sys.fn_cdc_increment_lsn returns the next LSN value after fromLSN
-	// This is the correct way to query CDC for incremental changes
-	incrementedFromLSN := fromLSN
-	if len(fromLSN) > 0 {
-		var err error
-		incrementedFromLSN, err = q.incrementLSN(ctx, fromLSN)
-		if err != nil {
-			// If increment fails (e.g., LSN is at max), no new changes available
-			slog.Debug("increment LSN failed, likely no new changes", "fromLSN", fmt.Sprintf("%x", fromLSN), "error", err)
-			return nil, nil
-		}
-		slog.Debug("incremented fromLSN for CDC query", "original", fmt.Sprintf("%x", fromLSN), "incremented", fmt.Sprintf("%x", incrementedFromLSN))
-	}
-
 	// Note: Use * only to avoid duplicate columns (CDC function already returns metadata)
-	// Also convert LSN to transaction time
+	// Also convert LSN to transaction time.
+	// We use the raw fromLSN without incrementing - this allows the first record
+	// to be fetched when starting fresh (fromLSN = min_lsn).
+	// Duplicate filtering is handled by the caller (poller) which skips records
+	// where __$start_lsn == lastProcessedLSN.
 	query := fmt.Sprintf(`
 		SELECT *, sys.fn_cdc_map_lsn_to_time(__$start_lsn) AS __$commit_time
 		FROM %s(@from_lsn, @to_lsn, N'%s')
@@ -173,7 +149,7 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 	`, fnName, rowFilterOption)
 
 	rows, err := q.db.QueryContext(ctx, query,
-		sql.Named("from_lsn", incrementedFromLSN),
+		sql.Named("from_lsn", fromLSN),
 		sql.Named("to_lsn", toLSN),
 	)
 	if err != nil {

--- a/internal/core/poller.go
+++ b/internal/core/poller.go
@@ -372,14 +372,18 @@ func (p *Poller) poll(ctx context.Context) error {
 
 		// Filter duplicates: CDC query returns records where __$start_lsn >= from_lsn,
 		// so we need to skip records where LSN == startLSN (the last processed LSN).
-		// When starting fresh (startLSN = min_lsn from GetMinLSN), there's no last processed
-		// LSN to filter, so all records are included.
-		// Note: startLSN.IsZero() means it's from GetMinLSN (first time), not from offset store.
+		//
+		// Filtering logic:
+		//   - stored.LSN != ""  means startLSN came from offset store (subsequent poll)
+		//     → Filter records where LSN == startLSN to avoid duplicates
+		//   - stored.LSN == ""  means startLSN came from GetMinLSN (fresh start / CDC restart)
+		//     → No filtering needed, include all records including the first one
+		//
+		// This fixes issue #132: CDC first query skips records due to incrementLSN logic.
 		filteredChanges := make([]cdc.Change, 0, len(cdcChanges))
 		for _, c := range cdcChanges {
-			// Skip records where LSN == startLSN (duplicate from previous poll)
-			// Only filter if startLSN was loaded from offset store (i.e., stored.LSN != "")
-			// If startLSN was from GetMinLSN (first time), no filtering needed.
+			// Skip duplicate records when startLSN came from offset store (stored.LSN != "")
+			// When starting fresh (stored.LSN == ""), all records are included.
 			if stored.LSN != "" && LSN(c.LSN).Compare(startLSN) == 0 {
 				slog.Debug("skipping duplicate record with LSN == startLSN",
 					"table", table,

--- a/internal/core/poller.go
+++ b/internal/core/poller.go
@@ -370,9 +370,28 @@ func (p *Poller) poll(ctx context.Context) error {
 			continue
 		}
 
+		// Filter duplicates: CDC query returns records where __$start_lsn >= from_lsn,
+		// so we need to skip records where LSN == startLSN (the last processed LSN).
+		// When starting fresh (startLSN = min_lsn from GetMinLSN), there's no last processed
+		// LSN to filter, so all records are included.
+		// Note: startLSN.IsZero() means it's from GetMinLSN (first time), not from offset store.
+		filteredChanges := make([]cdc.Change, 0, len(cdcChanges))
+		for _, c := range cdcChanges {
+			// Skip records where LSN == startLSN (duplicate from previous poll)
+			// Only filter if startLSN was loaded from offset store (i.e., stored.LSN != "")
+			// If startLSN was from GetMinLSN (first time), no filtering needed.
+			if stored.LSN != "" && LSN(c.LSN).Compare(startLSN) == 0 {
+				slog.Debug("skipping duplicate record with LSN == startLSN",
+					"table", table,
+					"lsn", fmt.Sprintf("%x", c.LSN))
+				continue
+			}
+			filteredChanges = append(filteredChanges, c)
+		}
+
 		// Convert cdc.Change to core.Change
-		changes := make([]Change, len(cdcChanges))
-		for i, c := range cdcChanges {
+		changes := make([]Change, len(filteredChanges))
+		for i, c := range filteredChanges {
 			changes[i] = Change{
 				Table:         c.Table,
 				TransactionID: c.TransactionID,

--- a/tests/flow/flow_test.go
+++ b/tests/flow/flow_test.go
@@ -801,6 +801,149 @@ func TestFlow_LSNComparison(t *testing.T) {
 	assert.False(t, nonZeroLSN.IsZero(), "non-empty LSN should not be zero")
 }
 
+// TestFlow_CDCFiltering_FreshStart tests that when starting fresh (no stored offset),
+// all records including the first one should be included.
+// This verifies the fix for issue #132: CDC first query skips records due to incrementLSN logic.
+func TestFlow_CDCFiltering_FreshStart(t *testing.T) {
+	// Simulate fresh start: stored.LSN == "" (no previous offset)
+	storedLSN := ""
+
+	// startLSN comes from GetMinLSN (first record's LSN)
+	startLSN := BuildLSN("0000000001000001")
+
+	// CDC query returns records where __$start_lsn >= from_lsn
+	// When from_lsn = min_lsn, all records are returned including the first
+	cdcChanges := []struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}{
+		{Table: "dbo.orders", TransactionID: "tx-1", LSN: BuildLSN("0000000001000001"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 1}},
+		{Table: "dbo.orders", TransactionID: "tx-1", LSN: BuildLSN("0000000001000002"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 2}},
+		{Table: "dbo.orders", TransactionID: "tx-2", LSN: BuildLSN("0000000001000003"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 3}},
+	}
+
+	// Apply filtering logic (same as poller.go)
+	// When stored.LSN == "" (fresh start), NO filtering - all records included
+	filteredChanges := make([]struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}, 0, len(cdcChanges))
+
+	for _, c := range cdcChanges {
+		// Skip records where LSN == startLSN ONLY when stored.LSN != ""
+		if storedLSN != "" && core.LSN(c.LSN).Compare(startLSN) == 0 {
+			continue // This should NOT happen when storedLSN == ""
+		}
+		filteredChanges = append(filteredChanges, c)
+	}
+
+	// Verify: All 3 records should be included (no filtering)
+	assert.Len(t, filteredChanges, 3, "fresh start should include ALL records including first one")
+	assert.Equal(t, BuildLSN("0000000001000001"), filteredChanges[0].LSN, "first record LSN should be included")
+	assert.Equal(t, BuildLSN("0000000001000002"), filteredChanges[1].LSN, "second record LSN should be included")
+	assert.Equal(t, BuildLSN("0000000001000003"), filteredChanges[2].LSN, "third record LSN should be included")
+}
+
+// TestFlow_CDCFiltering_SubsequentPoll tests that on subsequent polls,
+// the record at startLSN (last processed LSN) should be filtered to avoid duplicates.
+func TestFlow_CDCFiltering_SubsequentPoll(t *testing.T) {
+	// Simulate subsequent poll: stored.LSN has previous offset
+	storedLSN := "0000000001000001" // Previous poll processed up to this LSN
+
+	// startLSN comes from offset store (same as stored.LSN)
+	startLSN := BuildLSN("0000000001000001")
+
+	// CDC query returns records where __$start_lsn >= from_lsn
+	// This includes the last processed record (LSN = startLSN) which we must filter
+	cdcChanges := []struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}{
+		{Table: "dbo.orders", TransactionID: "tx-1", LSN: BuildLSN("0000000001000001"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 1}}, // Duplicate (already processed)
+		{Table: "dbo.orders", TransactionID: "tx-2", LSN: BuildLSN("0000000001000002"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 2}}, // New
+		{Table: "dbo.orders", TransactionID: "tx-3", LSN: BuildLSN("0000000001000003"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 3}}, // New
+	}
+
+	// Apply filtering logic (same as poller.go)
+	// When stored.LSN != "", filter records where LSN == startLSN
+	filteredChanges := make([]struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}, 0, len(cdcChanges))
+
+	for _, c := range cdcChanges {
+		// Skip records where LSN == startLSN when stored.LSN != ""
+		if storedLSN != "" && core.LSN(c.LSN).Compare(startLSN) == 0 {
+			continue // Filter the duplicate
+		}
+		filteredChanges = append(filteredChanges, c)
+	}
+
+	// Verify: Only 2 NEW records should be included (first one filtered as duplicate)
+	assert.Len(t, filteredChanges, 2, "subsequent poll should filter the duplicate at startLSN")
+	assert.Equal(t, BuildLSN("0000000001000002"), filteredChanges[0].LSN, "first filtered record should be LSN 2")
+	assert.Equal(t, BuildLSN("0000000001000003"), filteredChanges[1].LSN, "second filtered record should be LSN 3")
+}
+
+// TestFlow_CDCFiltering_CDCRestart tests that when CDC is disabled and re-enabled,
+// the stored offset becomes stale and min_lsn changes. The system should handle this correctly.
+func TestFlow_CDCFiltering_CDCRestart(t *testing.T) {
+	// Scenario: CDC was disabled and re-enabled
+	// Old stored.LSN is now stale (higher than current min_lsn)
+	// This simulates stored.LSN being cleared/reset (offset store reset)
+
+	// After CDC restart, stored.LSN should be cleared
+	storedLSN := "" // Offset was reset after CDC restart
+
+	// startLSN comes from GetMinLSN after CDC restart
+	startLSN := BuildLSN("0000000000000001") // New min_lsn after CDC restart
+
+	// CDC query returns records from the new min_lsn
+	cdcChanges := []struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}{
+		{Table: "dbo.orders", TransactionID: "tx-new-1", LSN: BuildLSN("0000000000000001"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 101}},
+		{Table: "dbo.orders", TransactionID: "tx-new-2", LSN: BuildLSN("0000000000000002"), Operation: core.OpInsert, Data: map[string]interface{}{"id": 102}},
+	}
+
+	// Apply filtering logic
+	filteredChanges := make([]struct {
+		Table         string
+		TransactionID string
+		LSN           []byte
+		Operation     core.Operation
+		Data          map[string]interface{}
+	}, 0, len(cdcChanges))
+
+	for _, c := range cdcChanges {
+		// When stored.LSN == "" (CDC restart, offset cleared), no filtering
+		if storedLSN != "" && core.LSN(c.LSN).Compare(startLSN) == 0 {
+			continue
+		}
+		filteredChanges = append(filteredChanges, c)
+	}
+
+	// Verify: All records from new min_lsn should be included
+	assert.Len(t, filteredChanges, 2, "CDC restart should fetch all records from new min_lsn")
+	assert.Equal(t, BuildLSN("0000000000000001"), filteredChanges[0].LSN, "first record after CDC restart should be included")
+}
+
 // TestFlow_ChangeBuilder tests the ChangeBuilder helper
 func TestFlow_ChangeBuilder(t *testing.T) {
 	change := NewChange("dbo.orders", "tx-test").


### PR DESCRIPTION
Fixes: #132

## What Changed
- Removed `incrementLSN` call before CDC query in `internal/cdc/query.go`
- Added LSN comparison filter in change processing loop to skip duplicates where `__$start_lsn == lastProcessedLSN`
- Added tests for LSN filtering logic

## Why
The previous logic used `sys.fn_cdc_increment_lsn()` to increment the starting LSN before querying. Combined with MSSQL's `>=` condition in `cdc.fn_cdc_get_all_changes_*`, this caused the first record to be skipped on fresh starts. When `fromLSN = min_lsn`, incrementing it would skip the first record entirely—or return nothing if only one record existed.

The fix simplifies the logic: always use `>= from_lsn` without increment, and filter duplicates at the application level.

## How to Test
1. Start CDC sync fresh (no existing offset) - verify first record is fetched correctly
2. Run subsequent queries - verify no duplicate processing occurs
3. Test CDC restart scenario (disable and re-enable CDC)

Closes #132

## Summary by Sourcery

Fix CDC change polling to avoid skipping the first record on fresh starts while still preventing duplicate processing across polls.

Bug Fixes:
- Stop incrementing the CDC fromLSN in queries so that the first available change is included when starting from the minimum LSN.
- Add duplicate filtering in the poller to skip records whose LSN matches the last processed LSN only on subsequent polls.

Tests:
- Add CDC flow tests covering fresh-start polling, subsequent polls, and CDC restart scenarios to validate LSN-based filtering behavior.