### PR TITLE
fix(store): use content-based hash as transactions.id to prevent CDC record loss

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,6 +190,11 @@ internal/store/migrations/
 -- Migration: 001_initial
 -- Module: dbkrab-store
 -- Description: Create initial schema
+-- Versioning Rules:
+--   - Major changes (breaking schema, new tables): increment major, require Devin confirmation
+--   - Schema table-structure changes: increment minor version (e.g., 1.1.0, 1.2.0)
+--   - Field-only changes (defaults, constraints without structural change): increment patch (e.g., 1.0.1)
+--   - All migrations live under the initial semver folder (1.0.0) per current policy decision
 
 CREATE TABLE IF NOT EXISTS transactions (...);
 CREATE INDEX IF NOT EXISTS idx_xxx ON transactions(...);
@@ -258,14 +263,16 @@ The `transactions` table stores captured CDC changes:
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `id` | INTEGER | Local autoincrement ID |
-| `transaction_id` | TEXT | MSSQL transaction ID (GUID) |
+| `id` | TEXT | Content-based hash (SHA256 of transaction_id+table_name+data+lsn+operation, first 16 bytes as 32-char hex). Primary key; prevents CDC record loss from LSN advancement skipping rows in same LSN group. |
+| `transaction_id` | TEXT | MSSQL transaction ID (GUID); NOT NULL for transaction boundary safety and diagnostics |
 | `table_name` | TEXT | Source table name |
 | `operation` | TEXT | Operation type (INSERT/DELETE/UPDATE_AFTER) |
 | `data` | TEXT | JSON-encoded row data |
-| `lsn` | TEXT | CDC LSN as hex string (e.g., `0x0000002D00000A760066`), nullable |
+| `lsn` | TEXT | CDC LSN as hex string (e.g., `0x0000002D00000A760066`), retained for tracing/debugging |
 | `changed_at` | TIMESTAMP | Transaction commit time from MSSQL |
 | `pulled_at` | TIMESTAMP | When the change was pulled |
+
+**Content-Based ID**: The `id` column uses SHA256(transaction_id + table_name + data + lsn + operation), truncated to the first 16 bytes (32 hex characters). This is deterministic and unique per change content. Using a content-based primary key instead of an auto-increment integer prevents record loss when LSN advancement skips remaining rows in the same LSN group during CDC pulls. Insert operations use `INSERT OR IGNORE` to silently skip duplicates.
 
 **LSN Semantics**: LSN (Log Sequence Number) is a transaction-level identifier from MSSQL CDC. Multiple row changes in the same transaction share the same LSN. Stored as a `0x`-prefixed hex string for readability and deterministic sorting.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
-	github.com/cnlangzi/sqlite v0.0.2
+	github.com/cnlangzi/sqlite v0.0.3
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/cnlangzi/sqlite v0.0.1 h1:VgONgs4kFgm9vVN83sa8sisdekG2enktQBsSt7KFe5c=
-github.com/cnlangzi/sqlite v0.0.1/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
-github.com/cnlangzi/sqlite v0.0.2 h1:KJS6d7daeol2xp0twHVGpChsnjSjMnEKPUNQGpIdTiI=
-github.com/cnlangzi/sqlite v0.0.2/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
+github.com/cnlangzi/sqlite v0.0.3 h1:P4qTIpC36Pbr5JIx3+WFpfOuKRTirhwY/i2vcgk1ErU=
+github.com/cnlangzi/sqlite v0.0.3/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/store/migrations/1.0.0/001_initial.sql
+++ b/internal/store/migrations/1.0.0/001_initial.sql
@@ -1,12 +1,20 @@
 -- Migration: 001_initial
 -- Module: dbkrab-store
 -- Description: Create initial schema for unified app DB (transactions, poller_state, offsets, dlq_entries)
-
+-- Versioning Rules:
+--   - Major changes (breaking schema, new tables): increment major, require Devin confirmation
+--   - Schema table-structure changes: increment minor version (e.g., 1.1.0, 1.2.0)
+--   - Field-only changes (defaults, constraints without structural change): increment patch (e.g., 1.0.1)
+--   - All migrations live under the initial semver folder (1.0.0) per current policy decision
+--
 -- =============================================================================
 -- transactions: stores CDC transaction changes
 -- =============================================================================
+-- id is a deterministic content-based hash: SHA256(transaction_id + table_name + data + lsn + operation)
+-- truncated to first 16 bytes (32 hex chars). This prevents CDC record loss caused by LSN advancement
+-- skipping rows in the same LSN group when using auto-increment primary key.
 CREATE TABLE IF NOT EXISTS transactions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT PRIMARY KEY,
     transaction_id TEXT NOT NULL,
     table_name TEXT NOT NULL,
     operation TEXT NOT NULL,

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -99,8 +100,8 @@ func (s *Store) Write(tx *core.Transaction) error {
 	}()
 
 	stmt, err := sqlTx.Prepare(`
-		INSERT INTO transactions (transaction_id, table_name, operation, data, lsn, changed_at, pulled_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT OR IGNORE INTO transactions (id, transaction_id, table_name, operation, data, lsn, changed_at, pulled_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
@@ -128,7 +129,14 @@ func (s *Store) Write(tx *core.Transaction) error {
 			lsnStr = "0x" + hex.EncodeToString(change.LSN)
 		}
 
+		// Compute content-based id: SHA256(transaction_id + table_name + data + lsn + operation)
+		// Take first 16 bytes and encode as 32-character hex string (deterministic, unique per change)
+		hashInput := tx.ID + change.Table + string(dataJSON) + lsnStr + change.Operation.String()
+		hash := sha256.Sum256([]byte(hashInput))
+		id := hex.EncodeToString(hash[:16]) // first 16 bytes = 32 hex chars
+
 		_, err = stmt.Exec(
+			id,
 			tx.ID,
 			change.Table,
 			change.Operation.String(),
@@ -233,7 +241,7 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 
 	var results []map[string]interface{}
 	for rows.Next() {
-		var id int
+		var id string
 		var resultTxID, resultTableName, resultOperation, dataStr, lsnStr string
 		var cdcTime, pulledAt interface{}
 

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -25,7 +25,7 @@ func newTestDB(t *testing.T) (*store.DB, string) {
 	// Create the required tables inline for testing (migrations are tested separately)
 	_, err = db.Writer.Exec(`
 		CREATE TABLE IF NOT EXISTS transactions (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			id TEXT PRIMARY KEY,
 			transaction_id TEXT NOT NULL,
 			table_name TEXT NOT NULL,
 			operation TEXT NOT NULL,
@@ -35,6 +35,12 @@ func newTestDB(t *testing.T) (*store.DB, string) {
 			pulled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		)
 	`)
+	require.NoError(t, err)
+
+	_, err = db.Writer.Exec(`CREATE INDEX IF NOT EXISTS idx_transaction_id ON transactions(transaction_id)`)
+	require.NoError(t, err)
+	_, err = db.Writer.Exec(`CREATE INDEX IF NOT EXISTS idx_table_name ON transactions(table_name)`)
+	require.NoError(t, err)
 	require.NoError(t, err)
 
 	_, err = db.Writer.Exec(`
@@ -368,4 +374,161 @@ func TestStore_WriteOps_Delete(t *testing.T) {
 	}
 	err = store.WriteOps(ops)
 	assert.NoError(t, err)
+}
+
+func TestStore_Write_DuplicateIgnored(t *testing.T) {
+	db, tmpDir := newTestDB(t)
+	defer func() {
+		_ = db.Close()
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	store, err := New(db)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	// Write the same transaction twice
+	tx := &core.Transaction{
+		ID: "tx-dup-001",
+		Changes: []core.Change{
+			{
+				Table:         "users",
+				TransactionID: "tx-dup-001",
+				LSN:           []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10},
+				Operation:     core.OpInsert,
+				Data: map[string]interface{}{
+					"id":   1,
+					"name": "alice",
+				},
+			},
+		},
+	}
+
+	err = store.Write(tx)
+	require.NoError(t, err)
+
+	// Write the same transaction again - should be ignored (not an error)
+	err = store.Write(tx)
+	require.NoError(t, err) // INSERT OR IGNORE should prevent duplicate
+
+	// Force commit to make data visible to reader
+	err = db.Flush()
+	require.NoError(t, err)
+
+	// Only one record should exist
+	changes, err := store.GetChanges(10)
+	require.NoError(t, err)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "tx-dup-001", changes[0]["transaction_id"])
+}
+
+func TestStore_Write_SameLSNDifferentContent(t *testing.T) {
+	db, tmpDir := newTestDB(t)
+	defer func() {
+		_ = db.Close()
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	store, err := New(db)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	// Two different rows in the same transaction (same LSN, different content)
+	tx := &core.Transaction{
+		ID: "tx-lsn-001",
+		Changes: []core.Change{
+			{
+				Table:         "users",
+				TransactionID: "tx-lsn-001",
+				LSN:           []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10},
+				Operation:     core.OpInsert,
+				Data: map[string]interface{}{
+					"id":   1,
+					"name": "alice",
+				},
+			},
+			{
+				Table:         "users",
+				TransactionID: "tx-lsn-001",
+				LSN:           []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, // same LSN
+				Operation:     core.OpInsert,
+				Data: map[string]interface{}{
+					"id":   2,
+					"name": "bob",
+				}, // different content
+			},
+		},
+	}
+
+	err = store.Write(tx)
+	require.NoError(t, err)
+
+	// Force commit
+	err = db.Flush()
+	require.NoError(t, err)
+
+	// Both rows should be stored (different content = different hash)
+	changes, err := store.GetChanges(10)
+	require.NoError(t, err)
+	assert.Len(t, changes, 2)
+}
+
+func TestStore_Write_ContentBasedId(t *testing.T) {
+	db, tmpDir := newTestDB(t)
+	defer func() {
+		_ = db.Close()
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	store, err := New(db)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	// Same content but different LSN -> different id
+	tx1 := &core.Transaction{
+		ID: "tx-lsn-002",
+		Changes: []core.Change{
+			{
+				Table:         "users",
+				TransactionID: "tx-lsn-002",
+				LSN:           []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10},
+				Operation:     core.OpInsert,
+				Data:          map[string]interface{}{"id": 1, "name": "alice"},
+			},
+		},
+	}
+	tx2 := &core.Transaction{
+		ID: "tx-lsn-002",
+		Changes: []core.Change{
+			{
+				Table:         "users",
+				TransactionID: "tx-lsn-002",
+				LSN:           []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11}, // different LSN
+				Operation:     core.OpInsert,
+				Data:          map[string]interface{}{"id": 1, "name": "alice"}, // same content
+			},
+		},
+	}
+
+	err = store.Write(tx1)
+	require.NoError(t, err)
+	err = store.Write(tx2)
+	require.NoError(t, err) // different LSN -> different hash, should both be stored
+
+	err = db.Flush()
+	require.NoError(t, err)
+
+	// Both should exist since LSN differs -> different hash ids
+	changes, err := store.GetChanges(10)
+	require.NoError(t, err)
+	assert.Len(t, changes, 2)
+
+	// Verify both ids are different (32-char hex strings)
+	ids := []string{}
+	for _, c := range changes {
+		ids = append(ids, c["id"].(string))
+	}
+	assert.NotEqual(t, ids[0], ids[1])
+	assert.Len(t, ids[0], 32)
+	assert.Len(t, ids[1], 32)
 }

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -41,6 +41,9 @@ func newTestDB(t *testing.T) (*store.DB, string) {
 	require.NoError(t, err)
 	_, err = db.Writer.Exec(`CREATE INDEX IF NOT EXISTS idx_table_name ON transactions(table_name)`)
 	require.NoError(t, err)
+	_, err = db.Writer.Exec(`CREATE INDEX IF NOT EXISTS idx_changed_at ON transactions(changed_at)`)
+	require.NoError(t, err)
+	_, err = db.Writer.Exec(`CREATE INDEX IF NOT EXISTS idx_lsn ON transactions(lsn)`)
 	require.NoError(t, err)
 
 	_, err = db.Writer.Exec(`


### PR DESCRIPTION
## Summary

Replace auto-increment integer primary key with a deterministic SHA-256 content hash to prevent CDC record loss caused by LSN advancement.

## Changes

### Schema
- **001_initial.sql**:  changed from  → 
- New indexes: , , , 
- Migration versioning rules documented

### Store write logic
-  — first 16 bytes → 32-char hex
- Uses  to skip duplicate change rows
-  and  columns preserved

### Tests
-  — same content written twice → 1 record
-  — different content same LSN → 2 records
-  — same content different LSN → 2 records (different hash)

### Dependencies
- Upgraded  to  (buffered write logging + SQLITE_BUFFER_SIZE support)

## Testing

```bash
SQLITE_BUFFER_SIZE=1 go test ./internal/store/sqlite/... -v -count=1
```

Closes #135

## Summary by Sourcery

Use a deterministic content-based hash as the primary key for stored CDC transactions to avoid duplicate inserts and prevent record loss when LSNs advance, and document corresponding schema and migration rules.

Bug Fixes:
- Ensure CDC changes with identical content are deduplicated while preserving distinct changes that share an LSN or have different LSNs via a content-based primary key.

Enhancements:
- Switch the transactions table primary key from an auto-increment integer to a content-derived text ID and add supporting indexes for common query fields.
- Extend the SQLite store write path to compute and use the content-based ID with INSERT OR IGNORE semantics.
- Document migration versioning rules and the semantics of the content-based transaction ID and LSN fields in the architecture docs.

Build:
- Bump the sqlite library dependency to v0.0.3 for improved buffered write behavior.

Tests:
- Add store tests covering duplicate-write deduplication, multiple changes sharing an LSN, and distinct IDs for identical content with different LSNs.