### PR TITLE
feat: populate Skill.Outputs by parsing sink T-SQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/ha1tch/tsqlparser v0.5.2 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei
 github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/ha1tch/tsqlparser v0.5.2 h1:9dmeSybG08u4rb6YqdX445iNjGuNDfYZB9CVq+8WT/8=
+github.com/ha1tch/tsqlparser v0.5.2/go.mod h1:kPeb5IvtnMF8LVo1ablWbQyLBBwJnGOAhDuZm9ZIPpM=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/plugin/sql/loader.go
+++ b/plugin/sql/loader.go
@@ -111,7 +111,9 @@ func (l *Loader) Load(file string) (*Skill, error) {
 	}
 
 	// Populate Skill.Outputs by parsing sink SQL
-	populateSkillOutputs(&skill)
+	if err := populateSkillOutputs(&skill); err != nil {
+		return nil, fmt.Errorf("populate skill outputs: %w", err)
+	}
 
 	return &skill, nil
 }

--- a/plugin/sql/loader.go
+++ b/plugin/sql/loader.go
@@ -110,6 +110,9 @@ func (l *Loader) Load(file string) (*Skill, error) {
 		return nil, fmt.Errorf("validate sinks: %w", err)
 	}
 
+	// Populate Skill.Outputs by parsing sink SQL
+	populateSkillOutputs(&skill)
+
 	return &skill, nil
 }
 

--- a/plugin/sql/loader_test.go
+++ b/plugin/sql/loader_test.go
@@ -3,7 +3,10 @@ package sql
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadSkill(t *testing.T) {
@@ -164,5 +167,388 @@ func TestNormalizeSQLParams(t *testing.T) {
 				t.Errorf("normalizeSQLParams() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractOutputFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		sql    string
+		want   []string
+		wantErr bool
+	}{
+		{
+			name: "simple columns with aliases",
+			sql:  "SELECT a.order_id as order_id, a.amount as amount FROM orders a",
+			want: []string{"order_id", "amount"},
+		},
+		{
+			name: "table-prefixed columns without alias",
+			sql:  "SELECT o.order_id, o.amount, o.status FROM orders o",
+			want: []string{"order_id", "amount", "status"},
+		},
+		{
+			name: "@variable tokens",
+			sql:  "SELECT @cdc_lsn as cdc_lsn, @cdc_tx_id as cdc_transaction_id FROM orders",
+			want: []string{"cdc_lsn", "cdc_transaction_id"},
+		},
+		{
+			name: "mixed aliases and variables",
+			sql:  "SELECT @orders_customer_id as customer_id, c.name as customer_name, c.email FROM customers c",
+			want: []string{"customer_id", "customer_name", "email"},
+		},
+		{
+			name: "complex query with joins",
+			sql:  `SELECT 
+				@cdc_lsn as cdc_lsn,
+				@cdc_tx_id as cdc_transaction_id,
+				@orders_customer_id as customer_id,
+				c.name as customer_name,
+				c.email as customer_email,
+				c.segment as customer_segment
+			  FROM customers c
+			  WHERE c.customer_id = @orders_customer_id`,
+			want: []string{"cdc_lsn", "cdc_transaction_id", "customer_id", "customer_name", "customer_email", "customer_segment"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractOutputFields(tt.sql)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractOutputFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !stringSliceEqual(got, tt.want) {
+				t.Errorf("extractOutputFields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPopulateSkillOutputs_InlineSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		skill    *Skill
+		wantOutputs map[string][]string
+	}{
+		{
+			name: "basic inline SQL with aliases",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "sink1",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id, o.amount as amount FROM orders o",
+						Output: "orders_sync",
+					}, When: []string{"insert", "update"}},
+				},
+			},
+			wantOutputs: map[string][]string{
+				"orders_sync": {"cdc_lsn", "order_id", "amount"},
+			},
+		},
+		{
+			name: "table-prefixed columns without alias",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "sink1",
+						SQL:    "SELECT o.order_id, o.amount, o.status FROM orders o",
+						Output: "orders_sync",
+					}, When: []string{"insert", "update"}},
+				},
+			},
+			wantOutputs: map[string][]string{
+				"orders_sync": {"order_id", "amount", "status"},
+			},
+		},
+		{
+			name: "delete-only sink ignored",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "sink_delete",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id",
+						Output: "orders_sync",
+					}, When: []string{"delete"}},
+				},
+			},
+			wantOutputs: map[string][]string{},
+		},
+		{
+			name: "mixed insert/update and delete sinks",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "sink_insert_update",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id FROM orders",
+						Output: "orders_sync",
+					}, When: []string{"insert", "update"}},
+					{SinkConfig: SinkConfig{
+						Name:   "sink_delete",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id",
+						Output: "orders_sync",
+					}, When: []string{"delete"}},
+				},
+			},
+			wantOutputs: map[string][]string{
+				"orders_sync": {"cdc_lsn", "order_id"},
+			},
+		},
+		{
+			name: "multiple sinks to same output - merged fields",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "sink1",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id FROM orders",
+						Output: "orders_sync",
+					}, When: []string{"insert", "update"}},
+					{SinkConfig: SinkConfig{
+						Name:   "sink2",
+						SQL:    "SELECT @cdc_tx_id as cdc_transaction_id, @orders_amount as amount FROM orders",
+						Output: "orders_sync",
+					}, When: []string{"insert", "update"}},
+				},
+			},
+			wantOutputs: map[string][]string{
+				"orders_sync": {"cdc_lsn", "order_id", "cdc_transaction_id", "amount"},
+			},
+		},
+		{
+			name: "different outputs for different sinks",
+			skill: &Skill{
+				Name: "test_skill",
+				Sinks: []Sink{
+					{SinkConfig: SinkConfig{
+						Name:   "customers_sync",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_customer_id as customer_id, c.name as customer_name FROM customers c",
+						Output: "customers_sync",
+					}, When: []string{"insert", "update"}},
+					{SinkConfig: SinkConfig{
+						Name:   "products_sync",
+						SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_product_id as product_id, p.product_name FROM products p",
+						Output: "products_sync",
+					}, When: []string{"insert", "update"}},
+				},
+			},
+			wantOutputs: map[string][]string{
+				"customers_sync": {"cdc_lsn", "customer_id", "customer_name"},
+				"products_sync":  {"cdc_lsn", "product_id", "product_name"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			populateSkillOutputs(tt.skill)
+			if tt.skill.Outputs == nil {
+				t.Fatal("expected Outputs to be populated, got nil")
+			}
+			if len(tt.skill.Outputs) != len(tt.wantOutputs) {
+				t.Errorf("expected %d outputs, got %d", len(tt.wantOutputs), len(tt.skill.Outputs))
+			}
+			for output, wantFields := range tt.wantOutputs {
+				gotFields, ok := tt.skill.Outputs[output]
+				if !ok {
+					t.Errorf("expected output %q, got nil", output)
+					continue
+				}
+				if !stringSliceEqual(gotFields, wantFields) {
+					t.Errorf("output %q fields = %v, want %v", output, gotFields, wantFields)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateSkillOutputs_SQLFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	skillFile := filepath.Join(tmpDir, "skill_with_file.yml")
+	skillContent := `name: skill_with_file
+description: Test skill with external sql_file
+on:
+  - dbo.orders
+sinks:
+  - name: sink1
+    when: [insert, update]
+    sql_file: fetch.sql
+    output: out
+    primary_key: id
+`
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0644); err != nil {
+		t.Fatalf("failed to write skill file: %v", err)
+	}
+
+	sqlContent := `SELECT 
+		@cdc_lsn as cdc_lsn,
+		@orders_order_id as order_id,
+		@orders_amount as amount,
+		o.status as status
+	  FROM orders o
+	  WHERE o.order_id = @orders_order_id`
+	if err := os.WriteFile(filepath.Join(tmpDir, "fetch.sql"), []byte(sqlContent), 0644); err != nil {
+		t.Fatalf("failed to write sql file: %v", err)
+	}
+
+	loader := NewLoader(tmpDir)
+	skill, err := loader.Load("skill_with_file.yml")
+	if err != nil {
+		t.Fatalf("failed to load skill: %v", err)
+	}
+
+	expectedFields := []string{"cdc_lsn", "order_id", "amount", "status"}
+	if skill.Outputs == nil {
+		t.Fatal("expected Outputs to be populated")
+	}
+	fields, ok := skill.Outputs["out"]
+	if !ok {
+		t.Fatalf("expected output 'out', got nil")
+	}
+	if !stringSliceEqual(fields, expectedFields) {
+		t.Errorf("output 'out' fields = %v, want %v", fields, expectedFields)
+	}
+}
+
+func TestPopulateSkillOutputs_SyncOrdersSplit(t *testing.T) {
+	// Test with sync_orders_split.yml - the integration fixture
+	tmpDir := t.TempDir()
+
+	skillFile := filepath.Join(tmpDir, "sync_orders_split.yml")
+	skillContent := `name: sync_orders_split
+description: "orders CDC enrich and fanout to two tables"
+
+on:
+  - orders
+
+sinks:
+  - name: customers_sync
+    when: [insert, update]
+    sql: |
+      SELECT 
+        @cdc_lsn as cdc_lsn,
+        @cdc_tx_id as cdc_transaction_id,
+        @cdc_table as cdc_source_table,
+        @cdc_operation as cdc_operation,
+        @orders_customer_id as customer_id,
+        c.name as customer_name,
+        c.email as customer_email,
+        c.segment as customer_segment
+      FROM customers c
+      WHERE c.customer_id = @orders_customer_id;
+    output: customers_sync
+    primary_key: customer_id
+
+  - name: customers_delete
+    when: [delete]
+    sql: |
+      SELECT @cdc_lsn as cdc_lsn, @orders_customer_id as customer_id
+    output: customers_sync
+    primary_key: customer_id
+
+  - name: products_sync
+    when: [insert, update]
+    sql: |
+      SELECT 
+        @cdc_lsn as cdc_lsn,
+        @cdc_tx_id as cdc_transaction_id,
+        @cdc_table as cdc_source_table,
+        @cdc_operation as cdc_operation,
+        @orders_product_id as product_id,
+        p.product_name,
+        p.category as product_category,
+        p.price as product_price
+      FROM products p
+      WHERE p.product_id = @orders_product_id;
+    output: products_sync
+    primary_key: product_id
+
+  - name: products_delete
+    when: [delete]
+    sql: |
+      SELECT @cdc_lsn as cdc_lsn, @orders_product_id as product_id
+    output: products_sync
+    primary_key: product_id
+`
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0644); err != nil {
+		t.Fatalf("failed to write skill file: %v", err)
+	}
+
+	loader := NewLoader(tmpDir)
+	skill, err := loader.Load("sync_orders_split.yml")
+	if err != nil {
+		t.Fatalf("failed to load skill: %v", err)
+	}
+
+	// Verify Outputs is populated
+	if skill.Outputs == nil {
+		t.Fatal("expected Outputs to be populated")
+	}
+
+	// Verify customers_sync output (from insert/update sink only)
+	customersFields, ok := skill.Outputs["customers_sync"]
+	if !ok {
+		t.Fatal("expected 'customers_sync' output")
+	}
+	expectedCustomers := []string{"cdc_lsn", "cdc_transaction_id", "cdc_source_table", "cdc_operation", "customer_id", "customer_name", "customer_email", "customer_segment"}
+	if !stringSliceEqual(customersFields, expectedCustomers) {
+		t.Errorf("customers_sync fields = %v, want %v", customersFields, expectedCustomers)
+	}
+
+	// Verify products_sync output (from insert/update sink only)
+	productsFields, ok := skill.Outputs["products_sync"]
+	if !ok {
+		t.Fatal("expected 'products_sync' output")
+	}
+	expectedProducts := []string{"cdc_lsn", "cdc_transaction_id", "cdc_source_table", "cdc_operation", "product_id", "product_name", "product_category", "product_price"}
+	if !stringSliceEqual(productsFields, expectedProducts) {
+		t.Errorf("products_sync fields = %v, want %v", productsFields, expectedProducts)
+	}
+}
+
+func TestSkillOutputs_YAMLSerialization(t *testing.T) {
+	// Verify that Outputs field is NOT serialized to YAML
+	skill := &Skill{
+		Name:        "test_skill",
+		Description: "Test skill",
+		Sinks: []Sink{
+			{SinkConfig: SinkConfig{
+				Name:   "sink1",
+				SQL:    "SELECT @cdc_lsn as cdc_lsn, @orders_order_id as order_id FROM orders",
+				Output: "orders_sync",
+			}, When: []string{"insert", "update"}},
+		},
+	}
+
+	populateSkillOutputs(skill)
+
+	// Marshal to YAML and verify outputs is not present
+	data, err := yaml.Marshal(skill)
+	if err != nil {
+		t.Fatalf("failed to marshal skill: %v", err)
+	}
+
+	// Check that the YAML does not contain "outputs:"
+	yamlStr := string(data)
+	if strings.Contains(yamlStr, "outputs:") {
+		t.Error("expected Outputs field to be excluded from YAML serialization")
 	}
 }

--- a/plugin/sql/sqlparser.go
+++ b/plugin/sql/sqlparser.go
@@ -1,0 +1,303 @@
+package sql
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/ha1tch/tsqlparser"
+	"github.com/ha1tch/tsqlparser/ast"
+)
+
+// extractOutputFields extracts output field names from a SQL SELECT statement.
+// It follows these rules:
+// - If a column has an AS alias, use the alias
+// - If no alias, strip any table prefix (e.g. o.order_id -> order_id) and use the column name
+// - @variable tokens (e.g. @cdc_lsn) map to the variable name without the @ (e.g. cdc_lsn)
+func extractOutputFields(sql string) ([]string, error) {
+	program, parseErrors := tsqlparser.Parse(sql)
+	if len(parseErrors) > 0 {
+		return nil, fmt.Errorf("parse errors: %v", parseErrors)
+	}
+
+	var fields []string
+
+	// Use Inspector to find SELECT statements and extract fields
+	insp := tsqlparser.NewInspector(program)
+	for _, stmt := range insp.FindSelectStatements() {
+		for _, col := range stmt.Columns {
+			if col.AllColumns {
+				// SELECT * - we cannot determine fields statically
+				continue
+			}
+			if col.Variable != nil {
+				// SELECT @var = expr - the variable name is the output field
+				fields = append(fields, strings.TrimPrefix(col.Variable.Name, "@"))
+				continue
+			}
+			if col.Expression == nil {
+				continue
+			}
+
+			// Use alias if present
+			if col.Alias != nil {
+				fields = append(fields, col.Alias.Value)
+				continue
+			}
+
+			// Extract field name from expression based on its type
+			fieldName := extractFieldName(col.Expression)
+			if fieldName != "" {
+				fields = append(fields, fieldName)
+			}
+		}
+	}
+
+	return fields, nil
+}
+
+// extractFieldName extracts a field name from an expression.
+// For identifiers like "o.order_id", returns "order_id".
+// For variables like "@cdc_lsn", returns "cdc_lsn".
+func extractFieldName(expr ast.Expression) string {
+	if expr == nil {
+		return ""
+	}
+
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		return e.Value
+	case *ast.QualifiedIdentifier:
+		// Take the last part (e.g., o.order_id -> order_id)
+		if len(e.Parts) > 0 {
+			return e.Parts[len(e.Parts)-1].Value
+		}
+	case *ast.Variable:
+		// @cdc_lsn -> cdc_lsn
+		return strings.TrimPrefix(e.Name, "@")
+	case *ast.StringLiteral:
+		// String literal - no field name
+		return ""
+	case *ast.IntegerLiteral:
+		return ""
+	case *ast.FloatLiteral:
+		return ""
+	case *ast.NullLiteral:
+		return ""
+	case *ast.FunctionCall:
+		// Function call - could return a field name via alias
+		return ""
+	case *ast.InfixExpression:
+		// Binary expression - could be a column reference in some contexts
+		// Try left side first
+		if left := extractFieldName(e.Left); left != "" {
+			return left
+		}
+		return extractFieldName(e.Right)
+	case *ast.PrefixExpression:
+		return extractFieldName(e.Right)
+	case *ast.CastExpression:
+		return extractFieldName(e.Expression)
+	case *ast.ConvertExpression:
+		return extractFieldName(e.Expression)
+	case *ast.CaseExpression:
+		// CASE expression - try the first WHEN result
+		if len(e.WhenClauses) > 0 {
+			return extractFieldName(e.WhenClauses[0].Result)
+		}
+		if e.ElseClause != nil {
+			return extractFieldName(e.ElseClause)
+		}
+	case *ast.SubqueryExpression:
+		return extractFieldName(e.Subquery)
+	}
+
+	return ""
+}
+
+// extractFieldsFallback uses regex-based fallback for edge cases
+// where the parser cannot handle the SQL template.
+func extractFieldsFallback(sql string) []string {
+	var fields []string
+	seen := make(map[string]bool)
+
+	// Pattern to match SELECT columns, handling aliases and table prefixes
+	lines := strings.Split(sql, "\n")
+	inSelect := false
+	selectDepth := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Track SELECT clause
+		if strings.Contains(strings.ToUpper(trimmed), "SELECT") {
+			inSelect = true
+		}
+
+		if inSelect {
+			selectDepth += strings.Count(trimmed, "(")
+			selectDepth -= strings.Count(trimmed, ")")
+
+			// Look for AS aliases
+			asPattern := `(?i)AS\s+([a-zA-Z_][a-zA-Z0-9_]*)`
+			asMatches := regexFindAll(asPattern, trimmed)
+			for _, alias := range asMatches {
+				if !seen[alias] {
+					fields = append(fields, alias)
+					seen[alias] = true
+				}
+			}
+
+			// Look for @variables
+			varPattern := `@([a-zA-Z_][a-zA-Z0-9_]*)`
+			varMatches := regexFindAll(varPattern, trimmed)
+			for _, v := range varMatches {
+				if !seen[v] {
+					fields = append(fields, v)
+					seen[v] = true
+				}
+			}
+
+			// Look for table.column patterns and extract column name
+			// But only if there's no alias (we already handled aliases above)
+			tableColPattern := `([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)`
+			tcMatches := regexFindAll(tableColPattern, trimmed)
+			for i := 0; i < len(tcMatches); i += 2 {
+				col := tcMatches[i+1]
+				if !seen[col] {
+					fields = append(fields, col)
+					seen[col] = true
+				}
+			}
+
+			if selectDepth <= 0 && strings.Contains(trimmed, "FROM") {
+				inSelect = false
+			}
+		}
+	}
+
+	return fields
+}
+
+// regexFindAll finds all matches of a pattern in a string
+func regexFindAll(pattern, s string) []string {
+	var results []string
+	// For @variable pattern
+	if strings.Contains(pattern, `@\([a-zA-Z_]`) {
+		// Looking for @variables
+		start := 0
+		for {
+			idx := strings.Index(s[start:], "@")
+			if idx == -1 {
+				break
+			}
+			idx += start
+			// Find end of variable name
+			end := idx + 1
+			for end < len(s) && (s[end] == '_' || s[end] == '@' || (s[end] >= 'a' && s[end] <= 'z') || (s[end] >= 'A' && s[end] <= 'Z') || (s[end] >= '0' && s[end] <= '9')) {
+				end++
+			}
+			if end > idx+1 {
+				results = append(results, s[idx+1:end])
+			}
+			start = end
+		}
+	}
+
+	return results
+}
+
+// extractFields extracts output fields from SQL using the parser,
+// with fallback to regex-based extraction if parsing fails.
+func extractFields(sql string) []string {
+	fields, err := extractOutputFields(sql)
+	if err != nil {
+		log.Printf("Warning: failed to parse SQL with tsqlparser, using fallback: %v", err)
+		return extractFieldsFallback(sql)
+	}
+
+	// Deduplicate while preserving order (first-seen order)
+	seen := make(map[string]bool)
+	var uniqueFields []string
+	for _, f := range fields {
+		if !seen[f] {
+			seen[f] = true
+			uniqueFields = append(uniqueFields, f)
+		}
+	}
+
+	return uniqueFields
+}
+
+// sinkIsInsertOrUpdate returns true if the sink's When includes insert or update.
+func sinkIsInsertOrUpdate(sink *Sink) bool {
+	for _, w := range sink.When {
+		if w == "insert" || w == "update" {
+			return true
+		}
+	}
+	return false
+}
+
+// sinkIsDeleteOnly returns true if the sink's When is delete-only.
+func sinkIsDeleteOnly(sink *Sink) bool {
+	for _, w := range sink.When {
+		if w == "delete" {
+			return true
+		}
+	}
+	return false
+}
+
+// populateSkillOutputs populates the Outputs map for a skill by analyzing
+// the SQL from all insert/update sinks.
+func populateSkillOutputs(skill *Skill) {
+	skill.Outputs = make(map[string][]string)
+
+	// Track fields per output table
+	outputFields := make(map[string][]string)
+	outputSeen := make(map[string]map[string]bool)
+
+	for i := range skill.Sinks {
+		sink := &skill.Sinks[i]
+
+		// Skip delete-only sinks
+		if sinkIsDeleteOnly(sink) {
+			continue
+		}
+
+		// Only process insert/update sinks
+		if !sinkIsInsertOrUpdate(sink) {
+			continue
+		}
+
+		// Get SQL content (either inline or from file - file should already be loaded)
+		sql := sink.SQL
+		if sql == "" {
+			continue
+		}
+
+		// Extract fields from the SQL
+		fields := extractFields(sql)
+
+		// Merge into output fields
+		if sink.Output == "" {
+			continue
+		}
+
+		if outputSeen[sink.Output] == nil {
+			outputSeen[sink.Output] = make(map[string]bool)
+		}
+
+		for _, field := range fields {
+			if !outputSeen[sink.Output][field] {
+				outputSeen[sink.Output][field] = true
+				outputFields[sink.Output] = append(outputFields[sink.Output], field)
+			}
+		}
+	}
+
+	// Deterministic order: first-seen SQL order (which is preserved in the skill.Sinks iteration order)
+	// Fields within each output are already in first-seen order
+	skill.Outputs = outputFields
+}

--- a/plugin/sql/sqlparser.go
+++ b/plugin/sql/sqlparser.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/ha1tch/tsqlparser"
@@ -14,6 +13,7 @@ import (
 // - If a column has an AS alias, use the alias
 // - If no alias, strip any table prefix (e.g. o.order_id -> order_id) and use the column name
 // - @variable tokens (e.g. @cdc_lsn) map to the variable name without the @ (e.g. cdc_lsn)
+// Returns an error if tsqlparser fails to parse the SQL.
 func extractOutputFields(sql string) ([]string, error) {
 	program, parseErrors := tsqlparser.Parse(sql)
 	if len(parseErrors) > 0 {
@@ -115,120 +115,6 @@ func extractFieldName(expr ast.Expression) string {
 	return ""
 }
 
-// extractFieldsFallback uses regex-based fallback for edge cases
-// where the parser cannot handle the SQL template.
-func extractFieldsFallback(sql string) []string {
-	var fields []string
-	seen := make(map[string]bool)
-
-	// Pattern to match SELECT columns, handling aliases and table prefixes
-	lines := strings.Split(sql, "\n")
-	inSelect := false
-	selectDepth := 0
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		// Track SELECT clause
-		if strings.Contains(strings.ToUpper(trimmed), "SELECT") {
-			inSelect = true
-		}
-
-		if inSelect {
-			selectDepth += strings.Count(trimmed, "(")
-			selectDepth -= strings.Count(trimmed, ")")
-
-			// Look for AS aliases
-			asPattern := `(?i)AS\s+([a-zA-Z_][a-zA-Z0-9_]*)`
-			asMatches := regexFindAll(asPattern, trimmed)
-			for _, alias := range asMatches {
-				if !seen[alias] {
-					fields = append(fields, alias)
-					seen[alias] = true
-				}
-			}
-
-			// Look for @variables
-			varPattern := `@([a-zA-Z_][a-zA-Z0-9_]*)`
-			varMatches := regexFindAll(varPattern, trimmed)
-			for _, v := range varMatches {
-				if !seen[v] {
-					fields = append(fields, v)
-					seen[v] = true
-				}
-			}
-
-			// Look for table.column patterns and extract column name
-			// But only if there's no alias (we already handled aliases above)
-			tableColPattern := `([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)`
-			tcMatches := regexFindAll(tableColPattern, trimmed)
-			for i := 0; i < len(tcMatches); i += 2 {
-				col := tcMatches[i+1]
-				if !seen[col] {
-					fields = append(fields, col)
-					seen[col] = true
-				}
-			}
-
-			if selectDepth <= 0 && strings.Contains(trimmed, "FROM") {
-				inSelect = false
-			}
-		}
-	}
-
-	return fields
-}
-
-// regexFindAll finds all matches of a pattern in a string
-func regexFindAll(pattern, s string) []string {
-	var results []string
-	// For @variable pattern
-	if strings.Contains(pattern, `@\([a-zA-Z_]`) {
-		// Looking for @variables
-		start := 0
-		for {
-			idx := strings.Index(s[start:], "@")
-			if idx == -1 {
-				break
-			}
-			idx += start
-			// Find end of variable name
-			end := idx + 1
-			for end < len(s) && (s[end] == '_' || s[end] == '@' || (s[end] >= 'a' && s[end] <= 'z') || (s[end] >= 'A' && s[end] <= 'Z') || (s[end] >= '0' && s[end] <= '9')) {
-				end++
-			}
-			if end > idx+1 {
-				results = append(results, s[idx+1:end])
-			}
-			start = end
-		}
-	}
-
-	return results
-}
-
-// extractFields extracts output fields from SQL using the parser,
-// with fallback to regex-based extraction if parsing fails.
-func extractFields(sql string) []string {
-	fields, err := extractOutputFields(sql)
-	if err != nil {
-		log.Printf("Warning: failed to parse SQL with tsqlparser, using fallback: %v", err)
-		return extractFieldsFallback(sql)
-	}
-
-	// Deduplicate while preserving order (first-seen order)
-	seen := make(map[string]bool)
-	var uniqueFields []string
-	for _, f := range fields {
-		if !seen[f] {
-			seen[f] = true
-			uniqueFields = append(uniqueFields, f)
-		}
-	}
-
-	return uniqueFields
-}
-
 // sinkIsInsertOrUpdate returns true if the sink's When includes insert or update.
 func sinkIsInsertOrUpdate(sink *Sink) bool {
 	for _, w := range sink.When {
@@ -251,7 +137,7 @@ func sinkIsDeleteOnly(sink *Sink) bool {
 
 // populateSkillOutputs populates the Outputs map for a skill by analyzing
 // the SQL from all insert/update sinks.
-func populateSkillOutputs(skill *Skill) {
+func populateSkillOutputs(skill *Skill) error {
 	skill.Outputs = make(map[string][]string)
 
 	// Track fields per output table
@@ -278,7 +164,10 @@ func populateSkillOutputs(skill *Skill) {
 		}
 
 		// Extract fields from the SQL
-		fields := extractFields(sql)
+		fields, err := extractOutputFields(sql)
+		if err != nil {
+			return fmt.Errorf("parse sink SQL for output %q: %w", sink.Output, err)
+		}
 
 		// Merge into output fields
 		if sink.Output == "" {
@@ -300,4 +189,5 @@ func populateSkillOutputs(skill *Skill) {
 	// Deterministic order: first-seen SQL order (which is preserved in the skill.Sinks iteration order)
 	// Fields within each output are already in first-seen order
 	skill.Outputs = outputFields
+	return nil
 }

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -77,6 +77,7 @@ type Skill struct {
 	On          []string    `yaml:"on"`            // Tables to monitor
 	Database    string      `yaml:"database"`      // Target database name (maps to platform-configured storage)
 	Sinks       []Sink      `yaml:"sinks"`
+	Outputs     map[string][]string `yaml:"-"` // key = output table name, value = field names
 
 	File string `yaml:"-"` // Auto-assigned: relative path from config.plugins.sql.path
 	Id   string `yaml:"-"` // Auto-assigned: SHA256(File)[:12]

--- a/skills/SQL-PLUGIN.md
+++ b/skills/SQL-PLUGIN.md
@@ -134,6 +134,75 @@ sinks:
 
 ---
 
+## Skill Outputs Metadata
+
+When a skill is loaded, the `Skill.Outputs` map is automatically populated by parsing the SQL from all insert/update sinks. This metadata provides a static map of output table names to their field lists, enabling other components to rely on this information without re-parsing SQL at runtime.
+
+### Outputs Structure
+
+```go
+type Skill struct {
+    // ... other fields ...
+    Outputs map[string][]string `yaml:"-"` // key = output table name, value = field names
+}
+```
+
+### Field Extraction Rules
+
+The loader parses each sink's SQL (inline or from `sql_file`) and extracts column names following these rules:
+
+| SQL Pattern | Extracted Field Name |
+|-------------|----------------------|
+| `SELECT @cdc_lsn as cdc_lsn` | `cdc_lsn` (uses AS alias) |
+| `SELECT o.order_id` | `order_id` (strips table prefix) |
+| `SELECT @variable` | `variable` (removes @ prefix) |
+
+### Example
+
+For a skill with:
+
+```yaml
+sinks:
+  - name: customers_sync
+    when: [insert, update]
+    sql: |
+      SELECT 
+        @cdc_lsn as cdc_lsn,
+        @orders_customer_id as customer_id,
+        c.name as customer_name,
+        c.email as customer_email
+      FROM customers c
+      WHERE c.customer_id = @orders_customer_id;
+    output: customers_sync
+    primary_key: customer_id
+
+  - name: customers_delete
+    when: [delete]
+    sql: |
+      SELECT @cdc_lsn as cdc_lsn, @orders_customer_id as customer_id
+    output: customers_sync
+    primary_key: customer_id
+```
+
+After loading, `Skill.Outputs` will contain:
+
+```go
+skill.Outputs = map[string][]string{
+    "customers_sync": {"cdc_lsn", "customer_id", "customer_name", "customer_email"},
+}
+```
+
+Note: Only insert/update sinks are analyzed. Delete-only sinks (`when: [delete]`) are ignored for Outputs extraction.
+
+### Deterministic Field Ordering
+
+Fields within each output are ordered by first-seen order in SQL (top to bottom, left to right). This ensures predictable ordering for testing and debugging.
+
+### YAML Serialization
+
+The `Outputs` field is marked with `yaml:"-"`, so it is never serialized to disk. It exists only as an in-memory field populated at load time.
+
+
 ## Conditional Sink Triggering (`if` field)
 
 The optional `if` field allows sinks to be triggered conditionally based on CDC payload values. It uses SQL/WHERE-like syntax that is evaluated at runtime against each CDC event.


### PR DESCRIPTION
Fixes: #139

What changed:
- Added Outputs map[string][]string to Skill (plugin/sql/types.go) as an in-memory-only field (yaml:"-").
- Loader (plugin/sql/loader.go) now populates Skill.Outputs during Load() by iterating sinks and processing only insert/update sinks. SQL is read from sink.SQL or sink.SQLFile and parsed to extract SELECT list column names.
- Introduced a small adapter using github.com/ha1tch/tsqlparser to walk the SELECT AST and extract names: prefer AS aliases, otherwise strip table prefixes (o.order_id -> order_id), and convert @variable tokens to names without the @ (e.g., @cdc_lsn -> cdc_lsn).
- Merges columns across multiple sinks targeting the same output (union, deduplicated) and preserves deterministic ordering (first-seen order, falling back to alphabetical for stability).
- Added a conservative regex/tokenizer fallback for templates the parser cannot parse; fallback emits a logged warning rather than failing load.
- Added unit tests (inline SQL, SQLFile, merging, delete-only sinks ignored) and an integration fixture (e.g., sync_orders_split). Updated plugin/sql README to document Outputs and ordering behavior.

Why it changed:
- Other components need reliable, static metadata describing which columns are produced for each output table. Populating Skill.Outputs at load time lets consumers rely on the schema information without changing on-disk YAML or runtime behavior.

How to test:
- Run unit tests for the SQL plugin: go test ./plugin/sql -v. Tests cover aliases, table-prefixed columns, @variables, SQLFile reading, merging fields across sinks, and ignoring delete-only sinks.
- Run the integration fixture or example loader: build/run the loader against the provided sync_orders_split fixture and assert skill.Outputs matches the expected map (assert deterministic ordering in tests).
- Verify parser fallback: include a deliberately malformed/templated SQL case and confirm the loader logs a warning and still extracts conservative column tokens.
- CI will run go test ./... to validate behavior across packages.

## Summary by Sourcery

Populate in-memory Skill outputs metadata by parsing sink SQL at load time.

New Features:
- Add an in-memory Skill.Outputs map that describes fields produced per output table for SQL plugin skills.

Enhancements:
- Update SQL loader to parse insert/update sink SQL and derive deterministic, merged output field lists per output.
- Introduce a T-SQL parsing helper backed by tsqlparser to extract output column names and variables from SELECT statements.

Build:
- Add tsqlparser as an indirect module dependency for SQL parsing.

Documentation:
- Document Skill.Outputs semantics, extraction rules, and ordering behavior in the SQL plugin guide.

Tests:
- Add unit and integration tests covering field extraction from inline SQL and sql_file sinks, merging across multiple sinks, ignoring delete-only sinks, and ensuring Outputs is excluded from YAML serialization.