### PR TITLE
refactor: extract shared ScannerFactory to internal/scanner package

### DIFF
--- a/internal/cdc/query.go
+++ b/internal/cdc/query.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	scannerpkg "github.com/cnlangzi/dbkrab/internal/scanner"
 )
 
 // validCaptureInstance validates capture instance name to prevent SQL injection
@@ -214,8 +216,8 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		// Extract LSN
 		var lsn []byte
 		if idx, ok := colIndex["__$start_lsn"]; ok {
-			if scanner, ok := dest[idx].(Scanner); ok {
-				if val, err := scanner.Value(); err == nil && val != nil {
+			if s, ok := dest[idx].(scannerpkg.Scanner); ok {
+				if val, err := s.Value(); err == nil && val != nil {
 					if b, ok := val.([]byte); ok {
 						lsn = b
 					}
@@ -226,13 +228,13 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		// Extract transaction ID
 		var txID string
 		if idx, ok := colIndex["__$transaction_id"]; ok {
-			if scanner, ok := dest[idx].(Scanner); ok {
-				if val, err := scanner.Value(); err == nil && val != nil {
+			if s, ok := dest[idx].(scannerpkg.Scanner); ok {
+				if val, err := s.Value(); err == nil && val != nil {
 					switch v := val.(type) {
 					case string:
 						txID = v
 					case []byte:
-						txID = FormatMSSQLGUID(v)
+						txID = scannerpkg.FormatMSSQLGUID(v)
 					default:
 						txID = fmt.Sprintf("%v", v)
 					}
@@ -243,8 +245,8 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		// Extract operation
 		var op int64
 		if idx, ok := colIndex["__$operation"]; ok {
-			if scanner, ok := dest[idx].(Scanner); ok {
-				if val, err := scanner.Value(); err == nil && val != nil {
+			if s, ok := dest[idx].(scannerpkg.Scanner); ok {
+				if val, err := s.Value(); err == nil && val != nil {
 					switch v := val.(type) {
 					case int64:
 						op = v
@@ -263,8 +265,8 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		// Extract commit time
 		var commitTime time.Time
 		if idx, ok := colIndex["__$commit_time"]; ok {
-			if scanner, ok := dest[idx].(Scanner); ok {
-				if val, err := scanner.Value(); err == nil && val != nil {
+			if s, ok := dest[idx].(scannerpkg.Scanner); ok {
+				if val, err := s.Value(); err == nil && val != nil {
 					// DateTime.Value returns RFC3339Nano string, handle both string and time.Time
 					switch v := val.(type) {
 					case time.Time:
@@ -286,8 +288,8 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 				continue
 			}
 
-			if scanner, ok := dest[i].(Scanner); ok {
-				if val, err := scanner.Value(); err == nil {
+			if s, ok := dest[i].(scannerpkg.Scanner); ok {
+				if val, err := s.Value(); err == nil {
 					data[strings.ToLower(col)] = val
 				}
 			}

--- a/internal/cdc/scanner.go
+++ b/internal/cdc/scanner.go
@@ -4,6 +4,41 @@ import (
 	"database/sql"
 	"strings"
 	"time"
+
+	"github.com/cnlangzi/dbkrab/internal/scanner"
+)
+
+// MSSQL type names - re-export from scanner package for compatibility
+const (
+	TypeBigInt           = scanner.TypeBigInt
+	TypeInt              = scanner.TypeInt
+	TypeSmallInt         = scanner.TypeSmallInt
+	TypeTinyInt          = scanner.TypeTinyInt
+	TypeBit              = scanner.TypeBit
+	TypeFloat            = scanner.TypeFloat
+	TypeReal             = scanner.TypeReal
+	TypeNumeric          = scanner.TypeNumeric
+	TypeDecimal          = scanner.TypeDecimal
+	TypeMoney            = scanner.TypeMoney
+	TypeSmallMoney       = scanner.TypeSmallMoney
+	TypeDateTime         = scanner.TypeDateTime
+	TypeDateTime2        = scanner.TypeDateTime2
+	TypeSmallDateTime    = scanner.TypeSmallDateTime
+	TypeDate             = scanner.TypeDate
+	TypeTime            = scanner.TypeTime
+	TypeDateTimeOffset   = scanner.TypeDateTimeOffset
+	TypeUniqueIdentifier = scanner.TypeUniqueIdentifier
+	TypeChar             = scanner.TypeChar
+	TypeVarchar          = scanner.TypeVarchar
+	TypeNChar            = scanner.TypeNChar
+	TypeNVarchar         = scanner.TypeNVarchar
+	TypeNText            = scanner.TypeNText
+	TypeText             = scanner.TypeText
+	TypeBinary           = scanner.TypeBinary
+	TypeVarBinary        = scanner.TypeVarBinary
+	TypeImage            = scanner.TypeImage
+	TypeXML              = scanner.TypeXML
+	TypeSQLVariant       = scanner.TypeSQLVariant
 )
 
 // ScannerFactory creates typed scanner instances based on MSSQL column types.
@@ -16,66 +51,31 @@ func NewScannerFactory(tz *time.Location) *ScannerFactory {
 	return &ScannerFactory{timezone: tz}
 }
 
-// MSSQL type names from DatabaseTypeName()
-const (
-	TypeBigInt           = "BIGINT"
-	TypeInt              = "INT"
-	TypeSmallInt         = "SMALLINT"
-	TypeTinyInt          = "TINYINT"
-	TypeBit              = "BIT"
-	TypeFloat            = "FLOAT"
-	TypeReal             = "REAL"
-	TypeNumeric          = "NUMERIC"
-	TypeDecimal          = "DECIMAL"
-	TypeMoney            = "MONEY"
-	TypeSmallMoney       = "SMALLMONEY"
-	TypeDateTime         = "DATETIME"
-	TypeDateTime2        = "DATETIME2"
-	TypeSmallDateTime    = "SMALLDATETIME"
-	TypeDate             = "DATE"
-	TypeTime             = "TIME"
-	TypeDateTimeOffset   = "DATETIMEOFFSET"
-	TypeUniqueIdentifier = "UNIQUEIDENTIFIER"
-	TypeChar             = "CHAR"
-	TypeVarchar          = "VARCHAR"
-	TypeNChar            = "NCHAR"
-	TypeNVarchar         = "NVARCHAR"
-	TypeNText            = "NTEXT"
-	TypeText             = "TEXT"
-	TypeBinary           = "BINARY"
-	TypeVarBinary        = "VARBINARY"
-	TypeImage            = "IMAGE"
-	TypeXML              = "XML"
-	TypeSQLVariant       = "SQL_VARIANT"
-)
-
 // createScanner creates a new scanner instance for the given MSSQL type name.
-func (sf *ScannerFactory) createScanner(typeName string) Scanner {
+func (sf *ScannerFactory) createScanner(typeName string) scanner.Scanner {
 	switch strings.ToUpper(typeName) {
 	case TypeBigInt, TypeInt, TypeSmallInt, TypeTinyInt:
-		return &Int64{}
+		return &scanner.Int64{}
 	case TypeFloat, TypeReal, TypeMoney, TypeSmallMoney:
-		return &Float64{}
+		return &scanner.Float64{}
 	case TypeNumeric, TypeDecimal:
-		return &NumericString{}
+		return &scanner.NumericString{}
 	case TypeUniqueIdentifier:
-		return &GUID{}
+		return &scanner.GUID{}
 	case TypeDateTime, TypeDateTime2, TypeSmallDateTime, TypeDate, TypeTime, TypeDateTimeOffset:
 		return NewDateTime(sf.timezone)
 	case TypeBit:
-		return &Bool{}
+		return &scanner.Bool{}
 	case TypeChar, TypeVarchar, TypeNChar, TypeNVarchar, TypeNText, TypeText, TypeXML, TypeSQLVariant:
-		return &String{}
+		return &scanner.String{}
 	case TypeBinary, TypeVarBinary, TypeImage:
-		return &Bytes{}
+		return &scanner.Bytes{}
 	default:
-		// Fallback to String for unknown types
-		return &String{}
+		return &scanner.String{}
 	}
 }
 
 // CreateDest creates a []interface{} of scanner pointers for rows.Scan.
-// columns is the column names, colTypes is the result of rows.ColumnTypes().
 func (sf *ScannerFactory) CreateDest(columns []string, colTypes []*sql.ColumnType) []interface{} {
 	dest := make([]interface{}, len(columns))
 	for i, ct := range colTypes {
@@ -84,3 +84,14 @@ func (sf *ScannerFactory) CreateDest(columns []string, colTypes []*sql.ColumnTyp
 	}
 	return dest
 }
+
+// Re-export scanner types for backward compatibility
+type (
+	Int64         = scanner.Int64
+	Float64       = scanner.Float64
+	NumericString = scanner.NumericString
+	GUID          = scanner.GUID
+	String        = scanner.String
+	Bool          = scanner.Bool
+	Bytes         = scanner.Bytes
+)

--- a/internal/cdc/types.go
+++ b/internal/cdc/types.go
@@ -1,13 +1,12 @@
 package cdc
 
 import (
-	"database/sql"
 	"database/sql/driver"
-	"encoding/hex"
 	"fmt"
 	"time"
-)
 
+	"github.com/cnlangzi/dbkrab/internal/scanner"
+)
 
 // Nullable represents a value that may be NULL.
 // It implements sql.Scanner and driver.Valuer.
@@ -23,7 +22,6 @@ func (n *Nullable[T]) Scan(src interface{}) error {
 		n.val, n.valid = *new(T), false
 		return nil
 	}
-	// Use safe type assertion to avoid panic for mismatched driver types
 	val, ok := src.(T)
 	if !ok {
 		return fmt.Errorf("Nullable[T].Scan: cannot convert %T to %T", src, *new(T))
@@ -38,185 +36,6 @@ func (n Nullable[T]) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	return n.val, nil
-}
-
-// Int64 is a nullable int64 scanner for MSSQL BIGINT.
-type Int64 struct {
-	val   int64
-	valid bool
-}
-
-// Scan implements sql.Scanner for Int64.
-func (i *Int64) Scan(src interface{}) error {
-	if src == nil {
-		i.val, i.valid = 0, false
-		return nil
-	}
-	switch v := src.(type) {
-	case int64:
-		i.val, i.valid = v, true
-		return nil
-	case int32:
-		i.val, i.valid = int64(v), true
-		return nil
-	case int:
-		i.val, i.valid = int64(v), true
-		return nil
-	case []byte:
-		if _, err := fmt.Sscanf(string(v), "%d", &i.val); err != nil {
-			i.val, i.valid = 0, false
-			return fmt.Errorf("Int64.Scan: cannot parse %q as int64: %w", string(v), err)
-		}
-		i.valid = true
-		return nil
-	default:
-		i.val, i.valid = 0, false
-		return fmt.Errorf("Int64.Scan: unsupported type %T", src)
-	}
-}
-
-// Value implements driver.Valuer for Int64.
-func (i Int64) Value() (driver.Value, error) {
-	if !i.valid {
-		return nil, nil
-	}
-	return i.val, nil
-}
-
-// Float64 is a nullable float64 scanner for MSSQL FLOAT/REAL.
-type Float64 struct {
-	val   float64
-	valid bool
-}
-
-// Scan implements sql.Scanner for Float64.
-func (f *Float64) Scan(src interface{}) error {
-	if src == nil {
-		f.val, f.valid = 0, false
-		return nil
-	}
-	switch v := src.(type) {
-	case float64:
-		f.val, f.valid = v, true
-		return nil
-	case float32:
-		f.val, f.valid = float64(v), true
-		return nil
-	case int64:
-		f.val, f.valid = float64(v), true
-		return nil
-	case []byte:
-		if _, err := fmt.Sscanf(string(v), "%f", &f.val); err != nil {
-			f.val, f.valid = 0, false
-			return fmt.Errorf("Float64.Scan: cannot parse %q as float64: %w", string(v), err)
-		}
-		f.valid = true
-		return nil
-	default:
-		f.val, f.valid = 0, false
-		return fmt.Errorf("Float64.Scan: unsupported type %T", src)
-	}
-}
-
-// Value implements driver.Valuer for Float64.
-func (f Float64) Value() (driver.Value, error) {
-	if !f.valid {
-		return nil, nil
-	}
-	return f.val, nil
-}
-
-// NumericString is a nullable string scanner for MSSQL DECIMAL/NUMERIC.
-// It preserves numeric string representation to avoid precision loss.
-type NumericString struct {
-	val   string
-	valid bool
-}
-
-// Scan implements sql.Scanner for NumericString.
-func (s *NumericString) Scan(src interface{}) error {
-	if src == nil {
-		s.val, s.valid = "", false
-		return nil
-	}
-	switch v := src.(type) {
-	case []byte:
-		s.val, s.valid = string(v), true
-	case string:
-		s.val, s.valid = v, true
-	default:
-		s.val, s.valid = fmt.Sprintf("%v", v), true
-	}
-	return nil
-}
-
-// Value implements driver.Valuer for NumericString.
-func (s NumericString) Value() (driver.Value, error) {
-	if !s.valid {
-		return nil, nil
-	}
-	return s.val, nil
-}
-
-// GUID is a nullable string scanner for MSSQL UNIQUEIDENTIFIER.
-// MSSQL uniqueidentifier stores GUID with mixed byte order:
-// - First 4 bytes: little-endian
-// - Next 2 bytes: little-endian
-// - Next 2 bytes: little-endian
-// - Last 8 bytes: big-endian
-// This type normalizes to standard GUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-type GUID struct {
-	val   string
-	valid bool
-}
-
-// Scan implements sql.Scanner for GUID.
-func (g *GUID) Scan(src interface{}) error {
-	if src == nil {
-		g.val, g.valid = "", false
-		return nil
-	}
-	bytes, ok := src.([]byte)
-	if !ok {
-		// Try to use as string directly
-		if s, ok := src.(string); ok {
-			g.val, g.valid = s, true
-			return nil
-		}
-		g.val, g.valid = fmt.Sprintf("%v", src), true
-		return nil
-	}
-	g.val, g.valid = formatMSSQLGUID(bytes), true
-	return nil
-}
-
-// Value implements driver.Valuer for GUID.
-func (g GUID) Value() (driver.Value, error) {
-	if !g.valid {
-		return nil, nil
-	}
-	return g.val, nil
-}
-
-// formatMSSQLGUID wraps FormatMSSQLGUID for internal use.
-func formatMSSQLGUID(b []byte) string {
-	return FormatMSSQLGUID(b)
-}
-
-// FormatMSSQLGUID formats a 16-byte MSSQL GUID to standard string format.
-// MSSQL uniqueidentifier uses mixed endian: first 3 groups little-endian, last group big-endian.
-func FormatMSSQLGUID(b []byte) string {
-	if len(b) != 16 {
-		return hex.EncodeToString(b)
-	}
-	// MSSQL GUID byte order: 3-2-1-0, 5-4, 7-6, 8-9-10-11-12-13-14-15
-	return fmt.Sprintf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		b[3], b[2], b[1], b[0], // First 4 bytes (LE)
-		b[5], b[4], // Next 2 bytes (LE)
-		b[7], b[6], // Next 2 bytes (LE)
-		b[8], b[9], // Start of last group - keep as-is (BE)
-		b[10], b[11], b[12], b[13], b[14], b[15],
-	)
 }
 
 // DateTime is a nullable time.Time scanner for MSSQL DATETIME/SMALLDATETIME.
@@ -246,7 +65,6 @@ func (d *DateTime) Scan(src interface{}) error {
 		d.val = d.convertTime(v)
 		d.valid = true
 	case []byte:
-		// Try parsing as time string
 		if parsed, err := time.Parse(time.RFC3339Nano, string(v)); err == nil {
 			d.val = d.convertTime(parsed)
 			d.valid = true
@@ -288,112 +106,6 @@ func (d DateTime) Value() (driver.Value, error) {
 	return d.val.Format(time.RFC3339Nano), nil
 }
 
-// String is a nullable string scanner for MSSQL VARCHAR/NVARCHAR/CHAR/NCHAR.
-type String struct {
-	val   string
-	valid bool
-}
-
-// Scan implements sql.Scanner for String.
-func (s *String) Scan(src interface{}) error {
-	if src == nil {
-		s.val, s.valid = "", false
-		return nil
-	}
-	switch v := src.(type) {
-	case []byte:
-		s.val, s.valid = string(v), true
-	case string:
-		s.val, s.valid = v, true
-	default:
-		s.val, s.valid = fmt.Sprintf("%v", v), true
-	}
-	return nil
-}
-
-// Value implements driver.Valuer for String.
-func (s String) Value() (driver.Value, error) {
-	if !s.valid {
-		return nil, nil
-	}
-	return s.val, nil
-}
-
-// Bool is a nullable bool scanner for MSSQL BIT/BOOLEAN.
-type Bool struct {
-	val   bool
-	valid bool
-}
-
-// Scan implements sql.Scanner for Bool.
-func (b *Bool) Scan(src interface{}) error {
-	if src == nil {
-		b.val, b.valid = false, false
-		return nil
-	}
-	switch v := src.(type) {
-	case bool:
-		b.val, b.valid = v, true
-	case int64:
-		b.val, b.valid = v != 0, true
-	case []byte:
-		if len(v) > 0 {
-			b.val, b.valid = v[0] != 0, true
-		} else {
-			b.val, b.valid = false, false
-		}
-	default:
-		b.val, b.valid = false, false
-	}
-	return nil
-}
-
-// Value implements driver.Valuer for Bool.
-func (b Bool) Value() (driver.Value, error) {
-	if !b.valid {
-		return nil, nil
-	}
-	return b.val, nil
-}
-
-// Bytes is a nullable []byte scanner for MSSQL VARBINARY/BINARY/IMAGE.
-type Bytes struct {
-	val   []byte
-	valid bool
-}
-
-// Scan implements sql.Scanner for Bytes.
-func (b *Bytes) Scan(src interface{}) error {
-	if src == nil {
-		b.val, b.valid = nil, false
-		return nil
-	}
-	switch v := src.(type) {
-	case []byte:
-		b.val, b.valid = v, true
-	case string:
-		b.val, b.valid = []byte(v), true
-	default:
-		b.val, b.valid = nil, false
-	}
-	return nil
-}
-
-// Value implements driver.Valuer for Bytes.
-func (b Bytes) Value() (driver.Value, error) {
-	if !b.valid {
-		return nil, nil
-	}
-	return b.val, nil
-}
-
-// Scanner is the interface implemented by types that can scan from SQL rows.
-// All our scanner types implement both sql.Scanner and driver.Valuer.
-type Scanner interface {
-	sql.Scanner
-	driver.Valuer
-}
-
 // Deprecated: convertCommitTime is kept for test compatibility.
 // Use DateTime.Scan with ScannerFactory instead.
 // convertCommitTime reinterprets MSSQL driver's "UTC" time as SQL Server's local timezone
@@ -404,13 +116,18 @@ type Scanner interface {
 //nolint:unused
 func convertCommitTime(driverTime time.Time, timezone *time.Location) time.Time {
 	if timezone == nil || timezone == time.Local {
-		// No timezone configured - use driver's value as-is
 		return driverTime.UTC()
 	}
-	// Reinterpret driver's "UTC" time as SQL Server's local timezone, then convert to UTC
 	return time.Date(
 		driverTime.Year(), driverTime.Month(), driverTime.Day(),
 		driverTime.Hour(), driverTime.Minute(), driverTime.Second(), driverTime.Nanosecond(),
 		timezone,
 	).UTC()
 }
+
+// Scanner is the interface implemented by types that can scan from SQL rows.
+// Alias for backward compatibility.
+type Scanner = scanner.Scanner
+
+// FormatMSSQLGUID re-exports from scanner package for backward compatibility.
+var FormatMSSQLGUID = scanner.FormatMSSQLGUID

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,359 @@
+package scanner
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Scanner is the interface implemented by types that can scan from SQL rows.
+// All scanner types implement both sql.Scanner and driver.Valuer.
+type Scanner interface {
+	sql.Scanner
+	driver.Valuer
+}
+
+// MSSQL type names from DatabaseTypeName()
+const (
+	TypeBigInt           = "BIGINT"
+	TypeInt              = "INT"
+	TypeSmallInt         = "SMALLINT"
+	TypeTinyInt          = "TINYINT"
+	TypeBit              = "BIT"
+	TypeFloat            = "FLOAT"
+	TypeReal             = "REAL"
+	TypeNumeric          = "NUMERIC"
+	TypeDecimal          = "DECIMAL"
+	TypeMoney            = "MONEY"
+	TypeSmallMoney       = "SMALLMONEY"
+	TypeDateTime         = "DATETIME"
+	TypeDateTime2        = "DATETIME2"
+	TypeSmallDateTime    = "SMALLDATETIME"
+	TypeDate             = "DATE"
+	TypeTime             = "TIME"
+	TypeDateTimeOffset   = "DATETIMEOFFSET"
+	TypeUniqueIdentifier = "UNIQUEIDENTIFIER"
+	TypeChar             = "CHAR"
+	TypeVarchar          = "VARCHAR"
+	TypeNChar            = "NCHAR"
+	TypeNVarchar         = "NVARCHAR"
+	TypeNText            = "NTEXT"
+	TypeText             = "TEXT"
+	TypeBinary           = "BINARY"
+	TypeVarBinary        = "VARBINARY"
+	TypeImage            = "IMAGE"
+	TypeXML              = "XML"
+	TypeSQLVariant       = "SQL_VARIANT"
+)
+
+// ScannerFactory creates typed scanner instances based on MSSQL column types.
+type ScannerFactory struct{}
+
+// NewScannerFactory creates a new ScannerFactory.
+func NewScannerFactory() *ScannerFactory {
+	return &ScannerFactory{}
+}
+
+// createScanner creates a new scanner instance for the given MSSQL type name.
+func (sf *ScannerFactory) createScanner(typeName string) Scanner {
+	switch strings.ToUpper(typeName) {
+	case TypeBigInt, TypeInt, TypeSmallInt, TypeTinyInt:
+		return &Int64{}
+	case TypeFloat, TypeReal, TypeMoney, TypeSmallMoney:
+		return &Float64{}
+	case TypeNumeric, TypeDecimal:
+		return &NumericString{}
+	case TypeUniqueIdentifier:
+		return &GUID{}
+	case TypeBit:
+		return &Bool{}
+	case TypeChar, TypeVarchar, TypeNChar, TypeNVarchar, TypeNText, TypeText, TypeXML, TypeSQLVariant:
+		return &String{}
+	case TypeBinary, TypeVarBinary, TypeImage:
+		return &Bytes{}
+	default:
+		// Fallback to String for unknown types
+		return &String{}
+	}
+}
+
+// CreateDest creates a []interface{} of scanner pointers for rows.Scan.
+// columns is the column names, colTypes is the result of rows.ColumnTypes().
+func (sf *ScannerFactory) CreateDest(colTypes []*sql.ColumnType) []interface{} {
+	dest := make([]interface{}, len(colTypes))
+	for i, ct := range colTypes {
+		scanner := sf.createScanner(ct.DatabaseTypeName())
+		dest[i] = scanner
+	}
+	return dest
+}
+
+// Int64 is a nullable int64 scanner for MSSQL BIGINT.
+type Int64 struct {
+	val   int64
+	valid bool
+}
+
+// Scan implements sql.Scanner for Int64.
+func (i *Int64) Scan(src interface{}) error {
+	if src == nil {
+		i.val, i.valid = 0, false
+		return nil
+	}
+	switch v := src.(type) {
+	case int64:
+		i.val, i.valid = v, true
+		return nil
+	case int32:
+		i.val, i.valid = int64(v), true
+		return nil
+	case int:
+		i.val, i.valid = int64(v), true
+		return nil
+	case []byte:
+		if _, err := fmt.Sscanf(string(v), "%d", &i.val); err != nil {
+			i.val, i.valid = 0, false
+			return fmt.Errorf("Int64.Scan: cannot parse %q as int64: %w", string(v), err)
+		}
+		i.valid = true
+		return nil
+	default:
+		i.val, i.valid = 0, false
+		return fmt.Errorf("Int64.Scan: unsupported type %T", src)
+	}
+}
+
+// Value implements driver.Valuer for Int64.
+func (i Int64) Value() (driver.Value, error) {
+	if !i.valid {
+		return nil, nil
+	}
+	return i.val, nil
+}
+
+// Float64 is a nullable float64 scanner for MSSQL FLOAT/REAL.
+type Float64 struct {
+	val   float64
+	valid bool
+}
+
+// Scan implements sql.Scanner for Float64.
+func (f *Float64) Scan(src interface{}) error {
+	if src == nil {
+		f.val, f.valid = 0, false
+		return nil
+	}
+	switch v := src.(type) {
+	case float64:
+		f.val, f.valid = v, true
+		return nil
+	case float32:
+		f.val, f.valid = float64(v), true
+		return nil
+	case int64:
+		f.val, f.valid = float64(v), true
+		return nil
+	case []byte:
+		if _, err := fmt.Sscanf(string(v), "%f", &f.val); err != nil {
+			f.val, f.valid = 0, false
+			return fmt.Errorf("Float64.Scan: cannot parse %q as float64: %w", string(v), err)
+		}
+		f.valid = true
+		return nil
+	default:
+		f.val, f.valid = 0, false
+		return fmt.Errorf("Float64.Scan: unsupported type %T", src)
+	}
+}
+
+// Value implements driver.Valuer for Float64.
+func (f Float64) Value() (driver.Value, error) {
+	if !f.valid {
+		return nil, nil
+	}
+	return f.val, nil
+}
+
+// NumericString is a nullable string scanner for MSSQL DECIMAL/NUMERIC.
+// It preserves numeric string representation to avoid precision loss.
+type NumericString struct {
+	val   string
+	valid bool
+}
+
+// Scan implements sql.Scanner for NumericString.
+func (s *NumericString) Scan(src interface{}) error {
+	if src == nil {
+		s.val, s.valid = "", false
+		return nil
+	}
+	switch v := src.(type) {
+	case []byte:
+		s.val, s.valid = string(v), true
+	case string:
+		s.val, s.valid = v, true
+	default:
+		s.val, s.valid = fmt.Sprintf("%v", v), true
+	}
+	return nil
+}
+
+// Value implements driver.Valuer for NumericString.
+func (s NumericString) Value() (driver.Value, error) {
+	if !s.valid {
+		return nil, nil
+	}
+	return s.val, nil
+}
+
+// GUID is a nullable string scanner for MSSQL UNIQUEIDENTIFIER.
+type GUID struct {
+	val   string
+	valid bool
+}
+
+// Scan implements sql.Scanner for GUID.
+func (g *GUID) Scan(src interface{}) error {
+	if src == nil {
+		g.val, g.valid = "", false
+		return nil
+	}
+	bytes, ok := src.([]byte)
+	if !ok {
+		if s, ok := src.(string); ok {
+			g.val, g.valid = s, true
+			return nil
+		}
+		g.val, g.valid = fmt.Sprintf("%v", src), true
+		return nil
+	}
+	g.val, g.valid = formatMSSQLGUID(bytes), true
+	return nil
+}
+
+// Value implements driver.Valuer for GUID.
+func (g GUID) Value() (driver.Value, error) {
+	if !g.valid {
+		return nil, nil
+	}
+	return g.val, nil
+}
+
+// formatMSSQLGUID formats a 16-byte MSSQL GUID to standard string format.
+func formatMSSQLGUID(b []byte) string {
+	if len(b) != 16 {
+		return hex.EncodeToString(b)
+	}
+	return fmt.Sprintf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		b[3], b[2], b[1], b[0],
+		b[5], b[4],
+		b[7], b[6],
+		b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+	)
+}
+
+// FormatMSSQLGUID exports formatMSSQLGUID for use by other packages.
+func FormatMSSQLGUID(b []byte) string {
+	return formatMSSQLGUID(b)
+}
+
+// String is a nullable string scanner for MSSQL VARCHAR/NVARCHAR/CHAR/NCHAR.
+type String struct {
+	val   string
+	valid bool
+}
+
+// Scan implements sql.Scanner for String.
+func (s *String) Scan(src interface{}) error {
+	if src == nil {
+		s.val, s.valid = "", false
+		return nil
+	}
+	switch v := src.(type) {
+	case []byte:
+		s.val, s.valid = string(v), true
+	case string:
+		s.val, s.valid = v, true
+	default:
+		s.val, s.valid = fmt.Sprintf("%v", v), true
+	}
+	return nil
+}
+
+// Value implements driver.Valuer for String.
+func (s String) Value() (driver.Value, error) {
+	if !s.valid {
+		return nil, nil
+	}
+	return s.val, nil
+}
+
+// Bool is a nullable bool scanner for MSSQL BIT/BOOLEAN.
+type Bool struct {
+	val   bool
+	valid bool
+}
+
+// Scan implements sql.Scanner for Bool.
+func (b *Bool) Scan(src interface{}) error {
+	if src == nil {
+		b.val, b.valid = false, false
+		return nil
+	}
+	switch v := src.(type) {
+	case bool:
+		b.val, b.valid = v, true
+	case int64:
+		b.val, b.valid = v != 0, true
+	case []byte:
+		if len(v) > 0 {
+			b.val, b.valid = v[0] != 0, true
+		} else {
+			b.val, b.valid = false, false
+		}
+	default:
+		b.val, b.valid = false, false
+	}
+	return nil
+}
+
+// Value implements driver.Valuer for Bool.
+func (b Bool) Value() (driver.Value, error) {
+	if !b.valid {
+		return nil, nil
+	}
+	return b.val, nil
+}
+
+// Bytes is a nullable []byte scanner for MSSQL VARBINARY/BINARY/IMAGE.
+type Bytes struct {
+	val   []byte
+	valid bool
+}
+
+// Scan implements sql.Scanner for Bytes.
+func (b *Bytes) Scan(src interface{}) error {
+	if src == nil {
+		b.val, b.valid = nil, false
+		return nil
+	}
+	switch v := src.(type) {
+	case []byte:
+		b.val, b.valid = v, true
+	case string:
+		b.val, b.valid = []byte(v), true
+	default:
+		b.val, b.valid = nil, false
+	}
+	return nil
+}
+
+// Value implements driver.Valuer for Bytes.
+func (b Bytes) Value() (driver.Value, error) {
+	if !b.valid {
+		return nil, nil
+	}
+	return b.val, nil
+}

--- a/plugin/sql/driver.go
+++ b/plugin/sql/driver.go
@@ -2,7 +2,8 @@ package sql
 
 import (
 	"database/sql"
-	"strings"
+
+	"github.com/cnlangzi/dbkrab/internal/scanner"
 )
 
 // DriverType represents the type of database driver
@@ -101,43 +102,28 @@ func (e *MSSQLExecutor) query(sqlStr string, args []interface{}) (*DataSet, erro
 		return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
 	}
 
-	// Identify which columns should be converted from []byte to string
-	// By default, convert []byte to string for all types unless explicitly kept as binary
-	byteColumns := make([]bool, len(colTypes))
-	for i, ct := range colTypes {
-		switch strings.ToUpper(ct.DatabaseTypeName()) {
-		case "BINARY", "VARBINARY", "IMAGE":
-			// Keep these as []byte (binary types)
-		default:
-			// Convert other []byte values to string (e.g., DECIMAL, NUMERIC, any unknown)
-			byteColumns[i] = true
-		}
-	}
+	// Use ScannerFactory to create appropriate scanners for each column
+	factory := scanner.NewScannerFactory()
+	dest := factory.CreateDest(colTypes)
 
 	// Scan results
 	var resultRows [][]interface{}
 	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		valuePtrs := make([]interface{}, len(columns))
-		for i := range values {
-			valuePtrs[i] = &values[i]
-		}
-
-		err := rows.Scan(valuePtrs...)
+		err := rows.Scan(dest...)
 		if err != nil {
 			return nil, NewExecutionError(sqlStr, map[string]interface{}{"args": args}, err)
 		}
 
-		// Convert []byte to string for non-binary types to avoid base64 encoding in JSON
-		for i, v := range values {
-			if byteColumns[i] {
-				if bs, ok := v.([]byte); ok {
-					values[i] = string(bs)
-				}
+		// Extract values from scanners
+		row := make([]interface{}, len(dest))
+		for i, d := range dest {
+			if s, ok := d.(scanner.Scanner); ok {
+				row[i], _ = s.Value()
+			} else {
+				row[i] = d
 			}
 		}
-
-		resultRows = append(resultRows, values)
+		resultRows = append(resultRows, row)
 	}
 
 	return &DataSet{


### PR DESCRIPTION
## Summary
Create a shared `internal/scanner` package that is used by both:
- CDC query layer (`internal/cdc`) - for processing MSSQL CDC changes
- SQL plugin (`plugin/sql`) - for MSSQL user query results

This ensures MSSQL `DECIMAL`/`NUMERIC` types are correctly converted to strings via `NumericString` scanner, preventing BLOB storage issues that caused base64 encoding in JSON responses.

## Changes
- **internal/scanner**: New package containing `ScannerFactory` and all scanner types (`Int64`, `Float64`, `NumericString`, `GUID`, `String`, `Bool`, `Bytes`)
- **internal/cdc**: Refactored to use `scanner` package, re-exports types for backward compatibility
- **plugin/sql/driver.go**: `MSSQLExecutor` now uses `scanner.ScannerFactory` instead of generic `interface{}` scanning

## Architecture
```
MSSQL DECIMAL → scanner.ScannerFactory.CreateDest() → NumericString.Scan() → Value() = "2100.000"
```

Both CDC and SQL plugin now use the same scanner logic, ensuring consistent type handling.

## Summary by Sourcery

Extract shared MSSQL scanner logic into a new internal package and adopt it in both the CDC layer and SQL plugin for consistent type handling.

New Features:
- Introduce an internal/scanner package providing a common ScannerFactory and typed MSSQL scanners for numeric, GUID, string, boolean, and binary values.

Enhancements:
- Refactor internal/cdc to delegate to the shared scanner package while re-exporting types and constants for backward compatibility.
- Update the MSSQL SQL plugin executor to use the shared ScannerFactory for row scanning, ensuring DECIMAL/NUMERIC values are surfaced as strings instead of base64-encoded blobs.