### PR TITLE
Sort logs by changed_at DESC and expand desktop fields

### DIFF
--- a/api/dashboard/pages/logs.html
+++ b/api/dashboard/pages/logs.html
@@ -114,7 +114,7 @@
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">ID</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Table</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Operation</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Transaction ID</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">TX ID</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">LSN <span class="text-[10px] normal-case">(tx-level)</span></th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Changed At</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Pulled At</th>
@@ -193,7 +193,7 @@ function renderDesktopRow(log) {
     
     return `
         <tr class="hover:bg-surfaceHover transition-colors">
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[120px]">${escapeHtml(log.id)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
@@ -201,7 +201,7 @@ function renderDesktopRow(log) {
                 </span>
             </td>
             <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono text-[10px] truncate max-w-[180px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</td>
             <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
             <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
             <td class="px-6 py-4 text-xs">

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -227,7 +227,7 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 		args = append(args, txID)
 	}
 
-	query += " ORDER BY id DESC"
+	query += " ORDER BY changed_at DESC"
 	if limit > 0 {
 		query += " LIMIT ?"
 		args = append(args, limit)


### PR DESCRIPTION
Fixes: #146

What changed:
- Backend (store.go): changed ORDER BY id DESC → ORDER BY changed_at DESC to sort by most recent change.
- Frontend (logs.html): table header "Transaction ID" → "TX ID" for consistency; removed `truncate max-w-[120px]` from id column and `truncate max-w-[180px]` from lsn column so full values render on desktop; desktop table now allows horizontal scrolling. Mobile view unchanged.

Why it changed:
- Users expect the most recent changes at the top of the Logs page and need to see full identifier/LSN values on desktop without forced truncation while preserving the mobile layout.

How to test:
1. Run the backend and frontend from this branch.
2. Create or seed multiple log entries with different changed_at timestamps. Open the Logs page and verify entries are ordered by changed_at descending (most recent first).
3. On a desktop/wide viewport: confirm the table header shows "TX ID", full id and lsn values are visible (no truncation), and a horizontal scrollbar appears if row content exceeds the viewport width.
4. On a mobile/narrow viewport: confirm the table layout and truncation behavior remain the same as before and no unwanted horizontal scroll is introduced.
5. (Optional) Run relevant unit/integration tests to ensure sorting and rendering behave as expected.

## Summary by Sourcery

Sort logs by most recent change and improve desktop visibility of log identifiers.

Enhancements:
- Change log retrieval to order results by changed_at in descending order so the newest changes appear first.
- Adjust logs page desktop table to show full ID and LSN values, shorten the transaction ID column label to 'TX ID', and rely on horizontal scrolling instead of truncation.