### PR TITLE
fix: reset target clears sinks data files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,8 @@ reset:
 	@sleep 2
 	@echo "Deleting app data files..."
 	@rm -rf /opt/dbkrab/data/app/*
+	@echo "Deleting sinks data files..."
+	@rm -rf /opt/dbkrab/data/sinks/*/*.db /opt/dbkrab/data/sinks/*/*.db-shm /opt/dbkrab/data/sinks/*/*.db-wal
 	@echo "Deleting logs..."
 	@rm -rf /opt/dbkrab/logs/*
 	@mkdir -p /opt/dbkrab/logs


### PR DESCRIPTION
## Summary

- `make reset` now clears sinks SQLite databases and their WAL files (`*.db`, `*.db-shm`, `*.db-wal`) under `/opt/dbkrab/data/sinks/`
- Previously only `/opt/dbkrab/data/app/*` was cleared, leaving stale sink data after reset

## Test plan

- [x] `make reset` runs without error
- [ ] Verify sinks data is cleared after reset

## Summary by Sourcery

Bug Fixes:
- Ensure make reset removes stale sink SQLite databases and related WAL/SHM files so environments are fully reset.