### PR TITLE
fix: correct UPDATE behavior and LSN offset handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
-	github.com/cnlangzi/sqlite v0.0.3
+	github.com/cnlangzi/sqlite v0.0.4
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/cnlangzi/sqlite v0.0.3 h1:P4qTIpC36Pbr5JIx3+WFpfOuKRTirhwY/i2vcgk1ErU=
-github.com/cnlangzi/sqlite v0.0.3/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
+github.com/cnlangzi/sqlite v0.0.4 h1:COPJi/UeFY973LKR5D8n8pG+xt8wOrHJyqHisxDtNY8=
+github.com/cnlangzi/sqlite v0.0.4/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/core/poller.go
+++ b/internal/core/poller.go
@@ -198,26 +198,20 @@ func (p *Poller) GetFromLSN(ctx context.Context, table string, stored offset.Off
 		return storedLSN, true, nil
 	}
 
-	// Case 2b: hasNewData == false (上次无数据，存储的是 lastLSN)
-	// 需要检查是否有新数据
-	nextLSN, err := p.querier.IncrementLSN(ctx, storedLSN)
-	if err != nil {
-		return nil, false, fmt.Errorf("increment LSN: %w", err)
-	}
-
+	// Case 2b: hasNewData == false (上次查询返回0行，存储的是 上次使用的LSN)
+	// 不要increment！直接用stored LSN查询，看是否有新数据
 	maxLSN, err := p.querier.GetMaxLSN(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("get max LSN: %w", err)
 	}
 
-	// Compare: if nextLSN > maxLSN, there is no new data
-	if LSN(nextLSN).Compare(LSN(maxLSN)) > 0 {
-		return nil, false, nil // 仍无新数据
+	// 如果 stored LSN 已经超过 max LSN，说明没有新数据
+	if LSN(storedLSN).Compare(LSN(maxLSN)) > 0 {
+		return nil, false, nil // LSN已超过max，无需查询
 	}
 
-	// 有新数据，返回 nextLSN（不是 stored.LSN）
-	// 因为 stored.LSN 是上次无数据时的旧位置
-	return nextLSN, true, nil
+	// 有数据，使用stored LSN作为起始点查询
+	return storedLSN, true, nil
 }
 
 // NewPoller creates a new poller

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -77,6 +77,15 @@ func (s *Sinker) writeOp(ctx context.Context, tx sqliteutil.TxExec, op core.Sink
 		OnConflict: op.Config.OnConflict,
 	}
 
+	slog.Debug("SQLiteSinker.writeOp: processing",
+		"database", s.name,
+		"output", op.Config.Output,
+		"opType", op.OpType,
+		"opTypeName", op.OpType.String(),
+		"primaryKey", op.Config.PrimaryKey,
+		"columns", len(op.DataSet.Columns),
+		"rows", len(op.DataSet.Rows))
+
 	switch op.OpType {
 	case core.OpInsert:
 		return sqliteutil.InsertInTx(tx, config, op.DataSet.Columns, op.DataSet.Rows)
@@ -86,12 +95,15 @@ func (s *Sinker) writeOp(ctx context.Context, tx sqliteutil.TxExec, op core.Sink
 		return sqliteutil.DeleteInTx(tx, config, op.DataSet.Columns, op.DataSet.Rows)
 	default:
 		// Defensively handle unknown operations by logging and dropping.
-		// This should not happen once upstream filtering and mapping are fixed,
-		// but we keep this to prevent DLQ storms from malformed data.
-		slog.Warn("SQLiteSinker.writeOp: unknown operation type, dropping",
-			"operation", op.OpType,
+		slog.Error("SQLiteSinker.writeOp: unsupported operation type, dropping",
+			"database", s.name,
 			"output", op.Config.Output,
-			"database", s.name)
+			"opType", op.OpType,
+			"opTypeName", op.OpType.String(),
+			"primaryKey", op.Config.PrimaryKey,
+			"columns", len(op.DataSet.Columns),
+			"rows", len(op.DataSet.Rows),
+			"hint", "supported types are: OpInsert(2), OpUpdateAfter(4), OpDelete(1)")
 		return nil
 	}
 }

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -94,7 +94,8 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 		// - "overwrite" (INSERT OR REPLACE): update if exists, insert if not
 		// - "skip" or "" (INSERT OR IGNORE): do nothing if exists, insert if not
 		// - otherwise: plain UPDATE (does nothing if row doesn't exist)
-		if config.OnConflict == "overwrite" {
+		switch config.OnConflict {
+		case "overwrite":
 			// Use INSERT OR REPLACE: inserts if not exists, replaces if exists
 			var placeholders []string
 			for i := range columns {
@@ -105,7 +106,7 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 				config.Output,
 				strings.Join(escapedColumns(columns), ", "),
 				strings.Join(placeholders, ", "))
-		} else if config.OnConflict == "skip" || config.OnConflict == "" {
+		case "skip", "":
 			// Use INSERT OR IGNORE: does nothing if row with PK already exists
 			var placeholders []string
 			for i := range columns {
@@ -116,7 +117,7 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 				config.Output,
 				strings.Join(escapedColumns(columns), ", "),
 				strings.Join(placeholders, ", "))
-		} else {
+		default:
 			// Plain UPDATE: only updates if row exists
 			var setClauses []string
 			for i, col := range columns {

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -3,6 +3,7 @@ package sqliteutil
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 )
 
@@ -21,12 +22,37 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 		return nil
 	}
 
+	slog.Debug("sqliteutil.InsertInTx: starting insert",
+		"table", config.Output,
+		"primaryKey", config.PrimaryKey,
+		"columns", columns,
+		"rows", len(rows))
+
 	for _, row := range rows {
 		sqlStr := BuildInsertSQL(config.Output, columns, true)
-		_, err := tx.Exec(sqlStr, row...)
+		slog.Debug("sqliteutil.InsertInTx: executing",
+			"table", config.Output,
+			"sql", sqlStr,
+			"rowLen", len(row))
+
+		result, err := tx.Exec(sqlStr, row...)
 		if err != nil {
+			slog.Error("sqliteutil.InsertInTx: exec failed",
+				"table", config.Output,
+				"sql", sqlStr,
+				"err", err)
 			return fmt.Errorf("execute: %w", err)
 		}
+
+		if result != nil {
+			rowsAffected, _ := result.RowsAffected()
+			slog.Debug("sqliteutil.InsertInTx: rows affected",
+				"table", config.Output,
+				"rowsAffected", rowsAffected)
+		}
+
+		slog.Debug("sqliteutil.InsertInTx: statement buffered",
+			"table", config.Output)
 	}
 
 	return nil
@@ -51,31 +77,101 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 		return fmt.Errorf("primary key %s not found", config.PrimaryKey)
 	}
 
+	slog.Debug("sqliteutil.UpdateInTx: starting update",
+		"table", config.Output,
+		"primaryKey", config.PrimaryKey,
+		"pkIndex", pkIndex,
+		"columns", columns,
+		"rows", len(rows))
+
 	for _, row := range rows {
-		var setClauses []string
+		pkValue := row[pkIndex]
+
+		var sqlStr string
 		var values []any
-		for i, col := range columns {
-			if col == config.PrimaryKey {
-				continue
+
+		// For UPDATE operations:
+		// - "overwrite" (INSERT OR REPLACE): update if exists, insert if not
+		// - "skip" or "" (INSERT OR IGNORE): do nothing if exists, insert if not
+		// - otherwise: plain UPDATE (does nothing if row doesn't exist)
+		if config.OnConflict == "overwrite" {
+			// Use INSERT OR REPLACE: inserts if not exists, replaces if exists
+			var placeholders []string
+			for i := range columns {
+				placeholders = append(placeholders, "?")
+				values = append(values, row[i])
 			}
-			setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
-			values = append(values, row[i])
+			sqlStr = fmt.Sprintf("INSERT OR REPLACE INTO %s (%s) VALUES (%s)",
+				config.Output,
+				strings.Join(escapedColumns(columns), ", "),
+				strings.Join(placeholders, ", "))
+		} else if config.OnConflict == "skip" || config.OnConflict == "" {
+			// Use INSERT OR IGNORE: does nothing if row with PK already exists
+			var placeholders []string
+			for i := range columns {
+				placeholders = append(placeholders, "?")
+				values = append(values, row[i])
+			}
+			sqlStr = fmt.Sprintf("INSERT OR IGNORE INTO %s (%s) VALUES (%s)",
+				config.Output,
+				strings.Join(escapedColumns(columns), ", "),
+				strings.Join(placeholders, ", "))
+		} else {
+			// Plain UPDATE: only updates if row exists
+			var setClauses []string
+			for i, col := range columns {
+				if col == config.PrimaryKey {
+					continue
+				}
+				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
+				values = append(values, row[i])
+			}
+			sqlStr = fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
+				config.Output,
+				strings.Join(setClauses, ", "),
+				config.PrimaryKey)
+			values = append(values, pkValue)
 		}
 
-		pkValue := row[pkIndex]
-		sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
-			config.Output,
-			strings.Join(setClauses, ", "),
-			config.PrimaryKey)
-		values = append(values, pkValue)
+		slog.Debug("sqliteutil.UpdateInTx: executing",
+			"table", config.Output,
+			"sql", sqlStr,
+			"pkValue", pkValue,
+			"valuesCount", len(values))
 
-		_, err := tx.Exec(sqlStr, values...)
+		result, err := tx.Exec(sqlStr, values...)
 		if err != nil {
+			slog.Error("sqliteutil.UpdateInTx: exec failed",
+				"table", config.Output,
+				"sql", sqlStr,
+				"pkValue", pkValue,
+				"err", err)
 			return fmt.Errorf("execute: %w", err)
 		}
+
+		if result != nil {
+			rowsAffected, _ := result.RowsAffected()
+			slog.Debug("sqliteutil.UpdateInTx: rows affected",
+				"table", config.Output,
+				"pkValue", pkValue,
+				"rowsAffected", rowsAffected)
+		}
+
+		slog.Debug("sqliteutil.UpdateInTx: statement buffered",
+			"table", config.Output,
+			"pkValue", pkValue)
 	}
 
 	return nil
+}
+
+// escapedColumns returns column names properly escaped for SQL
+func escapedColumns(columns []string) []string {
+	escaped := make([]string, len(columns))
+	for i, col := range columns {
+		escaped[i] = fmt.Sprintf("[%s]", col)
+	}
+	return escaped
 }
 
 // DeleteInTx deletes records from table.

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -103,18 +103,10 @@ func (s *Store) Write(tx *core.Transaction) (int, error) {
 		}
 	}()
 
-	stmt, err := sqlTx.Prepare(`
+	const insertSQL = `
 		INSERT OR IGNORE INTO changes (id, transaction_id, table_name, operation, data, lsn, changed_at, pulled_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`)
-	if err != nil {
-		return 0, fmt.Errorf("prepare statement: %w", err)
-	}
-	defer func() {
-		if err := stmt.Close(); err != nil {
-			slog.Warn("stmt.Close error", "error", err)
-		}
-	}()
+	`
 
 	rowsInserted := 0
 	for _, change := range tx.Changes {
@@ -144,7 +136,8 @@ func (s *Store) Write(tx *core.Transaction) (int, error) {
 			id = hex.EncodeToString(hash[:16])
 		}
 
-		res, err := stmt.Exec(
+		res, err := sqlTx.Exec(
+			insertSQL,
 			id,
 			tx.ID,
 			change.Table,


### PR DESCRIPTION
## Summary

Fixed two bugs that caused CDC data to not be written to SQLite sink:

1. **UpdateInTx using wrong SQL strategy**: Plain `UPDATE ... WHERE pk = ?` silently affects 0 rows when the row doesn't exist in the sink. This caused UPDATE operations on new data to be lost.

2. **LSN offset increment bug**: When `hasNewData=false`, the code was incorrectly incrementing the stored LSN before querying. This could skip over CDC data that existed between the stored LSN and the incremented LSN.

## Changes

- `internal/sqliteutil/util.go`: UpdateInTx now uses `INSERT OR REPLACE` for `on_conflict=overwrite` and `INSERT OR IGNORE` for `on_conflict=skip`
- `internal/core/poller.go`: When `hasNewData=false`, use stored LSN directly without incrementing

## Test plan

- [x] Verified Cost table now receives 10 rows (was 0)
- [x] Verified Costitem table now receives 9 rows (was 0)
- [x] All existing tests pass

## Summary by Sourcery

Adjust SQLite sink update semantics and CDC polling logic to ensure change data is reliably written while improving observability.

Bug Fixes:
- Ensure UPDATE operations on SQLite sinks correctly insert or replace rows based on on_conflict behavior instead of silently affecting zero rows when the target row does not exist.
- Prevent CDC polling from skipping records by using the stored LSN directly when the previous query returned no rows, rather than incrementing it.

Enhancements:
- Add structured debug and error logging around SQLite insert, update, and sink write operations for easier diagnostics of CDC behavior and unsupported operation types.