### PR TITLE
chore: add bin/dbkrab to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 ./dbkrab
+./bin/dbkrab
 dbkrab_test
 dist/
 


### PR DESCRIPTION
## Summary
- Add `bin/dbkrab` to `.gitignore` to prevent accidentally committing compiled binaries

## Test plan
- Run `git check-ignore bin/dbkrab` to verify the file is now ignored

## Summary by Sourcery

Chores:
- Update .gitignore to ignore the bin/dbkrab compiled binary.