### PR TITLE
log: add per-table debug logs in GetChanges (from/to LSN)

### DIFF
--- a/internal/cdc/query.go
+++ b/internal/cdc/query.go
@@ -259,6 +259,7 @@ func (q *Querier) GetChanges(ctx context.Context, captureInstance string, tableN
 		})
 	}
 
+	slog.Debug("GetChanges completed", "table", tableName, "from_lsn", hex.EncodeToString(fromLSN), "to_lsn", hex.EncodeToString(toLSN), "changes", len(changes))
 	return changes, rows.Err()
 }
 


### PR DESCRIPTION
Fixes: #158

What changed:
- Add a Debug-level structured log in internal/cdc/query.go inside GetChanges() that emits one log line per table immediately after successfully obtaining changes.
- Logged fields: table (table identifier), from_lsn (hex string), to_lsn (hex string, equals the global max LSN passed in), changes (integer len(changes)).
- Do not log next_lsn or any internal bookkeeping values.

Why it changed:
- Poller logs were previously aggregated across all tables, making it hard to see the exact LSN ranges and change counts per table. Per-table debug logs make it possible for operators to inspect from/to LSNs and the number of rows returned for each table during a poll.

How to test:
1. Enable debug logging for the service (set logger to Debug).
2. Run a poll cycle (or the poller) that exercises one or more configured tables.
3. Confirm that for each configured table there is exactly one debug log entry with the keys: table, from_lsn, to_lsn, changes.
4. Verify the values: from_lsn matches the input fromLSN, to_lsn matches the global max LSN passed into GetChanges, and changes equals len(changes). Ensure the log does not contain next_lsn or other internal fields.

Example expected debug log:
table=my_schema.my_table from_lsn=0/16B6A8F0 to_lsn=0/16B6AFF0 changes=12

Implementation note: change added in internal/cdc/query.go within GetChanges().

## Summary by Sourcery

New Features:
- Log a debug message after GetChanges completes that includes table name, from_lsn, to_lsn, and the number of changes returned.