### PR TITLE
fix: skip bad sinks/skills instead of aborting entire batch

### DIFF
--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -102,14 +102,14 @@ func (m *Manager) Write(ctx context.Context, sinks []core.Sink) error {
 	slog.Info("SinkerManager.Write: routing sinks",
 		"total_sinks", len(sinks))
 
-	// Group sinks by database
+	// Group sinks by database; skip sinks with missing database config instead of aborting
 	sinksByDB := make(map[string][]core.Sink)
 	for _, sink := range sinks {
 		dbName := sink.Config.Database
 		if dbName == "" {
-			slog.Error("SinkerManager.Write: sink has no database configured",
+			slog.Warn("SinkerManager.Write: sink has no database configured, skipping",
 				"sink_name", sink.Config.Name)
-			return fmt.Errorf("sink %s has no database configured", sink.Config.Name)
+			continue
 		}
 		sinksByDB[dbName] = append(sinksByDB[dbName], sink)
 	}
@@ -125,17 +125,17 @@ func (m *Manager) Write(ctx context.Context, sinks []core.Sink) error {
 
 		sinker, err := m.GetSinker(dbName)
 		if err != nil {
-			slog.Error("SinkerManager.Write: failed to get sinker",
+			slog.Warn("SinkerManager.Write: failed to get sinker, skipping database",
 				"database", dbName,
 				"error", err)
-			return fmt.Errorf("get sinker for %s: %w", dbName, err)
+			continue
 		}
 
 		if err := sinker.Write(ctx, dbSinks); err != nil {
-			slog.Error("SinkerManager.Write: write failed",
+			slog.Error("SinkerManager.Write: write failed for database, skipping",
 				"database", dbName,
 				"error", err)
-			return fmt.Errorf("write to %s: %w", dbName, err)
+			continue
 		}
 
 		slog.Debug("SinkerManager.Write: write completed",

--- a/plugin/sql/plugin.go
+++ b/plugin/sql/plugin.go
@@ -395,10 +395,10 @@ func (p *Plugin) Handle(tx *core.Transaction) ([]core.Sink, error) {
 
 		sinks, err := p.engine.HandleWithSkill(tx, skill)
 		if err != nil {
-			slog.Error("Plugin.Handle: skill execution failed",
+			slog.Error("Plugin.Handle: skill execution failed, skipping skill",
 				"skill", skill.Name,
 				"error", err)
-			return nil, fmt.Errorf("skill %s handle: %w", skill.Name, err)
+			continue
 		}
 
 		slog.Debug("Plugin.Handle: skill execution completed",

--- a/plugin/sql/types_test.go
+++ b/plugin/sql/types_test.go
@@ -213,6 +213,42 @@ func TestSkillFilterByOperation(t *testing.T) {
 	}
 }
 
+func TestSkillFilterByOperation_InsertOnly(t *testing.T) {
+	skill := &Skill{
+		Name: "test",
+		On:   []string{"dbo.orders"},
+		Sinks: []Sink{
+			{SinkConfig: SinkConfig{Name: "insert_only"}, When: []string{"insert"}},
+			{SinkConfig: SinkConfig{Name: "update_only"}, When: []string{"update"}},
+			{SinkConfig: SinkConfig{Name: "delete_only"}, When: []string{"delete"}},
+		},
+	}
+
+	insertSinks := skill.FilterByOperation(Insert)
+	if len(insertSinks) != 1 {
+		t.Errorf("expected 1 insert sink, got %d", len(insertSinks))
+	}
+	if insertSinks[0].Name != "insert_only" {
+		t.Errorf("expected insert sink name 'insert_only', got '%s'", insertSinks[0].Name)
+	}
+
+	updateSinks := skill.FilterByOperation(Update)
+	if len(updateSinks) != 1 {
+		t.Errorf("expected 1 update sink, got %d", len(updateSinks))
+	}
+	if updateSinks[0].Name != "update_only" {
+		t.Errorf("expected update sink name 'update_only', got '%s'", updateSinks[0].Name)
+	}
+
+	deleteSinks := skill.FilterByOperation(Delete)
+	if len(deleteSinks) != 1 {
+		t.Errorf("expected 1 delete sink, got %d", len(deleteSinks))
+	}
+	if deleteSinks[0].Name != "delete_only" {
+		t.Errorf("expected delete sink name 'delete_only', got '%s'", deleteSinks[0].Name)
+	}
+}
+
 func TestFilterSinks(t *testing.T) {
 	sinks := []SinkConfig{
 		{Name: "sink1", On: "dbo.orders"},


### PR DESCRIPTION
## Summary

Fixes two issues that caused a single misconfigured sink or skill to abort the entire processing pipeline.

### Changes

**1. internal/sinker/manager.go** — individual sink errors now skip instead of abort:
- Sink with missing database config → skip, continue with other sinks
- GetSinker failure → skip database, continue with other databases
- sinker.Write failure → skip database, continue with other databases

**2. plugin/sql/plugin.go** — individual skill errors now skip instead of abort:
- Skill execution failure → skip skill, continue with remaining skills

### Why this matters

When multiple skills exist in the same pipeline (e.g., a test skill + production skill), a misconfigured test skill would previously abort the entire batch, blocking correct production skills from running.

### Testing

All existing unit tests pass (11 packages). No behavior change for correctly configured sinks/skills.

## Summary by Sourcery

Allow sink and skill processing to continue when individual sinks or skills fail, instead of aborting the entire batch.

Bug Fixes:
- Skip sinks without a configured database instead of failing the entire sink write operation.
- Skip databases whose sinker cannot be created instead of aborting processing for all sinks.
- Skip databases whose sinker write fails so other databases in the batch can still be processed.
- Skip individual SQL skills that fail during execution so remaining skills in the transaction can continue.