### PR TITLE
feat: add Migrate() to Sinker interface with SQLite implementation

### DIFF
--- a/cmd/app/dashboard/pages/sinks/{id}.html
+++ b/cmd/app/dashboard/pages/sinks/{id}.html
@@ -14,6 +14,15 @@
             <h2 class="text-2xl sm:text-3xl font-bold text-text">Sink: <span id="sink-name-display" class="text-primary">Loading...</span></h2>
         </div>
         <p class="text-sm text-textMuted">Execute SQL queries against this sink database</p>
+        <div class="mt-3">
+            <button onclick="runMigration()" 
+                    class="flex items-center justify-center gap-2 px-4 py-2 bg-warning hover:bg-warningHover text-white font-medium rounded-lg transition-all duration-200 shadow-md">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                <span>Migrate</span>
+            </button>
+        </div>
     </div>
 
     <!-- Query Section -->
@@ -74,8 +83,11 @@
         </div>
     </div>
 
+    <!-- Migration Status -->
+    <div id="migration-status" class="hidden mb-6 p-4 rounded-xl border flex items-center gap-3" role="status" aria-live="polite"></div>
+
     <!-- Error Message -->
-    <div id="error-message" class="hidden mt-6 p-4 rounded-xl border border-error/30 bg-error/10 text-error" role="alert" aria-live="polite"></div>
+    <div id="error-message" class="hidden mb-6 p-4 rounded-xl border border-error/30 bg-error/10 text-error" role="alert" aria-live="polite"></div>
 </div>
 
 <script>
@@ -259,6 +271,63 @@ function showError(message) {
 function hideError() {
     const errorEl = document.getElementById('error-message');
     errorEl.classList.add('hidden');
+}
+
+async function runMigration() {
+    if (!confirm('Run migration for this sink database?')) {
+        return;
+    }
+
+    hideError();
+    hideMigrationStatus();
+
+    // Show loading state in migration status
+    const statusEl = document.getElementById('migration-status');
+    statusEl.className = 'mb-6 p-4 rounded-xl border border-primary/30 bg-primary/10 flex items-center gap-3';
+    statusEl.innerHTML = `
+        <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-primary"></div>
+        <span class="text-text">Running migration...</span>
+    `;
+    statusEl.classList.remove('hidden');
+
+    try {
+        const response = await fetch(`/api/sinks/${encodeURIComponent(sinkId)}/migrate`, {
+            method: 'POST',
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+            statusEl.className = 'mb-6 p-4 rounded-xl border border-success/30 bg-success/10 flex items-center gap-3';
+            statusEl.innerHTML = `
+                <svg class="w-5 h-5 text-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                </svg>
+                <span class="text-text font-medium">Migration completed successfully</span>
+            `;
+        } else {
+            statusEl.className = 'mb-6 p-4 rounded-xl border border-error/30 bg-error/10 flex items-center gap-3';
+            statusEl.innerHTML = `
+                <svg class="w-5 h-5 text-error flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+                <span class="text-error">Migration failed: ${escapeHtml(data.error)}</span>
+            `;
+        }
+    } catch (err) {
+        statusEl.className = 'mb-6 p-4 rounded-xl border border-error/30 bg-error/10 flex items-center gap-3';
+        statusEl.innerHTML = `
+            <svg class="w-5 h-5 text-error flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            <span class="text-error">Error running migration: ${escapeHtml(err.message)}</span>
+        `;
+    }
+}
+
+function hideMigrationStatus() {
+    const statusEl = document.getElementById('migration-status');
+    statusEl.classList.add('hidden');
 }
 
 function escapeHtml(text) {

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -234,6 +234,7 @@ func (s *Server) registerAPIRoutes() {
 	api.Get("/sinks/list", s.handleSinksList, xun.WithViewer(&xun.JsonViewer{}))
 	api.Get("/sinks/{id}/tables", s.handleSinkTables, xun.WithViewer(&xun.JsonViewer{}))
 	api.Post("/sinks/{id}/query", s.handleSinkQuery, xun.WithViewer(&xun.JsonViewer{}))
+	api.Post("/sinks/{id}/migrate", s.handleSinkMigrate, xun.WithViewer(&xun.JsonViewer{}))
 
 	api.Get("/health", s.handleHealth, xun.WithViewer(&xun.JsonViewer{}))
 	api.Get("/overview", s.handleOverview)
@@ -1308,6 +1309,48 @@ func (s *Server) handleSinkQuery(c *xun.Context) error {
 		"columns": columns,
 		"rows":    queryResults,
 		"count":   len(queryResults),
+	})
+}
+
+// handleSinkMigrate handles POST /api/sinks/{id}/migrate
+func (s *Server) handleSinkMigrate(c *xun.Context) error {
+	id := c.Request.PathValue("id")
+	if id == "" {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   "sink id is required",
+		})
+	}
+
+	// Find sink by ID
+	sinkCfg, err := s.getSinkById(id)
+	if err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   err.Error(),
+		})
+	}
+
+	// Get sinker instance
+	sinker, err := s.sinkerManager.GetSinker(sinkCfg.Name)
+	if err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   fmt.Sprintf("failed to get sinker: %v", err),
+		})
+	}
+
+	// Run migration
+	if err := sinker.Migrate(context.Background()); err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   fmt.Sprintf("migration failed: %v", err),
+		})
+	}
+
+	return c.View(map[string]any{
+		"success": true,
+		"message": "migration completed successfully",
 	})
 }
 

--- a/internal/sinker/sinker.go
+++ b/internal/sinker/sinker.go
@@ -18,6 +18,10 @@ type Sinker interface {
 	// Write writes a batch of sink operations to the sink with context for timeout/cancellation
 	Write(ctx context.Context, ops []core.Sink) error
 
+	// Migrate runs the migration for this sinker's database.
+	// It re-discovers and re-applies migrations from the configured migrations path.
+	Migrate(ctx context.Context) error
+
 	// Close closes the sinker and releases resources
 	Close() error
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -2,20 +2,25 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/sqliteutil"
+	"github.com/yaitoo/sqle"
+	"github.com/yaitoo/sqle/migrate"
 )
 
 // Sinker implements sinker.Sinker for SQLite.
 type Sinker struct {
-	name   string
-	db     *DB
-	mu     sync.Mutex
-	closed bool
+	name       string
+	db         *DB
+	migrations string // path to migration SQL files
+	mu         sync.Mutex
+	closed     bool
 }
 
 // NewSinker creates a new SQLite sinker.
@@ -26,8 +31,9 @@ func NewSinker(name string, dsn string, migrations string) (*Sinker, error) {
 	}
 
 	return &Sinker{
-		name: name,
-		db:   db,
+		name:       name,
+		db:         db,
+		migrations: migrations,
 	}, nil
 }
 
@@ -119,4 +125,36 @@ func (s *Sinker) Close() error {
 	s.closed = true
 
 	return s.db.Close()
+}
+
+// Migrate runs the migration for this sinker's database.
+// It re-discovers and re-applies migrations from the configured migrations path.
+func (s *Sinker) Migrate(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.migrations == "" {
+		return errors.New("no migrations path configured")
+	}
+
+	slog.Info("SQLiteSinker.Migrate: starting migration",
+		"database", s.name,
+		"migrations", s.migrations)
+
+	sqleDB := sqle.Open(s.db.Writer.DB)
+	migrator := migrate.New(sqleDB)
+	if err := migrator.Discover(os.DirFS(s.migrations), migrate.WithModule("dbkrab")); err != nil {
+		return fmt.Errorf("load migrations: %w", err)
+	}
+	if err := migrator.Init(ctx); err != nil {
+		return fmt.Errorf("init migrations: %w", err)
+	}
+	if err := migrator.Migrate(ctx); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+
+	slog.Info("SQLiteSinker.Migrate: migration completed",
+		"database", s.name)
+
+	return nil
 }


### PR DESCRIPTION
## Summary

Add Migrate(ctx) method to sinker.Sinker interface, implemented in SQLite sinker via yaitoo/sqle/migrate.

### Changes

- internal/sinker/sinker.go: + Migrate(ctx context.Context) error to interface
- internal/sinker/sqlite/writer.go: store migrations path in struct; implement Migrate() as Discover -> Init -> Migrate
- cmd/app/server.go: + POST /api/sinks/{id}/migrate handler
- cmd/app/dashboard/pages/sinks/{id}.html: Migrate button with inline status feedback (loading/success/error)

### Testing

- Build OK
- Tests OK (sqlite sinker tests pass)

Closes #166

## Summary by Sourcery

Add a migration capability to sinkers and expose it through the SQLite implementation and HTTP/API/dashboard flows.

New Features:
- Introduce a Migrate(ctx) operation on the sinker interface to run database migrations for sinks.
- Implement SQLite sinker migrations using sqle/migrate based on a configured migrations path.
- Expose a POST /api/sinks/{id}/migrate endpoint to trigger migrations for a specific sink.
- Add a Migrate button and inline migration status feedback to the sink details dashboard page.

Enhancements:
- Extend the SQLite sinker to track the migrations directory alongside its database handle.