### PR TITLE
feat: add replay capability for CDC changes (issue #170)

### DIFF
--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -117,15 +117,15 @@ func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *Repla
 	return nil
 }
 
-// buildTransaction builds a core.Transaction from core.Change slice
+// buildTransaction builds a Transaction from Change slice
 // It groups changes by transaction ID and filters out UPDATE_BEFORE operations
-func (r *ReplayService) buildTransaction(changes []core.Change) *Transaction {
+func (r *ReplayService) buildTransaction(changes []Change) *Transaction {
 	// Group by transaction ID, filtering out UPDATE_BEFORE
 	txMap := make(map[string]*Transaction)
 
 	for _, c := range changes {
-		// Filter out UPDATE_BEFORE operations (operation == 3)
-		if c.Operation == core.OpUpdateBefore { // OpUpdateBefore
+		// Filter out UPDATE_BEFORE operations
+		if c.Operation == OpUpdateBefore {
 			slog.Debug("buildTransaction: silently dropping UPDATE_BEFORE change",
 				"table", c.Table,
 				"tx_id", c.TransactionID,
@@ -139,7 +139,7 @@ func (r *ReplayService) buildTransaction(changes []core.Change) *Transaction {
 			txMap[c.TransactionID] = tx
 		}
 
-		// Already core.Change, add directly
+		// Already Change, add directly
 		tx.AddChange(c)
 	}
 

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -1,0 +1,141 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cnlangzi/dbkrab/internal/cdc"
+)
+
+// ReplayService replays CDC changes from the store
+type ReplayService struct {
+	store   Store
+	handler Handler
+}
+
+// Store interface for replay operations (uses cdc.Change)
+type Store interface {
+	GetLSNs() ([]string, error)
+	GetChangesWithLSN(lsn string) ([]cdc.Change, error)
+}
+
+// NewReplayService creates a new ReplayService
+func NewReplayService(store Store, handler Handler) *ReplayService {
+	return &ReplayService{
+		store:   store,
+		handler: handler,
+	}
+}
+
+// Execute replays all CDC changes from the store in LSN order
+func (r *ReplayService) Execute(ctx context.Context) error {
+	// Get all unique LSNs from store
+	lsns, err := r.store.GetLSNs()
+	if err != nil {
+		return fmt.Errorf("failed to get LSNs: %w", err)
+	}
+
+	if len(lsns) == 0 {
+		slog.Info("no changes to replay")
+		return nil
+	}
+
+	slog.Info("starting replay", "lsn_count", len(lsns))
+
+	// Process each LSN in order
+	for i, lsn := range lsns {
+		if err := r.replayLSN(ctx, lsn); err != nil {
+			slog.Error("failed to replay LSN", "lsn", lsn, "index", i+1, "total", len(lsns), "error", err)
+			return fmt.Errorf("replay LSN %s: %w", lsn, err)
+		}
+
+		slog.Debug("replayed LSN", "lsn", lsn, "index", i+1, "total", len(lsns))
+	}
+
+	slog.Info("replay completed", "total_lsns", len(lsns))
+	return nil
+}
+
+// replayLSN replays all changes for a specific LSN
+func (r *ReplayService) replayLSN(ctx context.Context, lsn string) error {
+	// Get all changes for this LSN
+	changes, err := r.store.GetChangesWithLSN(lsn)
+	if err != nil {
+		return fmt.Errorf("get changes for LSN %s: %w", lsn, err)
+	}
+
+	if len(changes) == 0 {
+		slog.Debug("no changes for LSN", "lsn", lsn)
+		return nil
+	}
+
+	// Build transaction from changes
+	tx := r.buildTransaction(changes)
+
+	// Handle the transaction
+	if err := r.handler.Handle(ctx, tx); err != nil {
+		return fmt.Errorf("handle transaction %s: %w", tx.ID, err)
+	}
+
+	return nil
+}
+
+// buildTransaction builds a core.Transaction from cdc.Change slice
+// It groups changes by transaction ID and filters out UPDATE_BEFORE operations
+func (r *ReplayService) buildTransaction(changes []cdc.Change) *Transaction {
+	// Group by transaction ID, filtering out UPDATE_BEFORE
+	txMap := make(map[string]*Transaction)
+
+	for _, c := range changes {
+		// Filter out UPDATE_BEFORE operations (operation == 3)
+		if c.Operation == 3 { // OpUpdateBefore
+			slog.Debug("buildTransaction: silently dropping UPDATE_BEFORE change",
+				"table", c.Table,
+				"tx_id", c.TransactionID,
+				"lsn", fmt.Sprintf("%x", c.LSN))
+			continue
+		}
+
+		tx, exists := txMap[c.TransactionID]
+		if !exists {
+			tx = NewTransaction(c.TransactionID)
+			txMap[c.TransactionID] = tx
+		}
+
+		// Convert cdc.Change to core.Change
+		coreChange := ConvertToCoreChange(c)
+		tx.AddChange(coreChange)
+	}
+
+	// Convert map to slice - should only have one transaction per LSN
+	if len(txMap) == 0 {
+		return &Transaction{
+			ID:      "",
+			Changes: []Change{},
+		}
+	}
+
+	// Get the first (and only) transaction
+	for _, tx := range txMap {
+		return tx
+	}
+
+	return &Transaction{
+		ID:      "",
+		Changes: []Change{},
+	}
+}
+
+// ConvertToCoreChange converts cdc.Change to core.Change
+func ConvertToCoreChange(c cdc.Change) Change {
+	return Change{
+		Table:         c.Table,
+		TransactionID: c.TransactionID,
+		LSN:           c.LSN,
+		Operation:     Operation(c.Operation),
+		Data:          c.Data,
+		CommitTime:    c.CommitTime,
+		ID:            "", // ID will be computed if needed
+	}
+}

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-
-	"github.com/cnlangzi/dbkrab/internal/core"
-	"github.com/cnlangzi/dbkrab/internal/store"
 )
+
+// ReplayStore defines the interface for replay operations
+// This is a local interface to avoid import cycle with store package
+type ReplayStore interface {
+	GetLSNs() ([]string, error)
+	GetChangesWithLSN(lsn string) ([]Change, error)
+}
 
 // ReplayService replays CDC changes from the store
 type ReplayService struct {
-	store   store.Store
+	store   ReplayStore
 	handler Handler
 }
 
@@ -24,7 +28,7 @@ type ReplayResult struct {
 }
 
 // NewReplayService creates a new ReplayService
-func NewReplayService(store store.Store, handler Handler) *ReplayService {
+func NewReplayService(store ReplayStore, handler Handler) *ReplayService {
 	return &ReplayService{
 		store:   store,
 		handler: handler,

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -6,22 +6,25 @@ import (
 	"log/slog"
 
 	"github.com/cnlangzi/dbkrab/internal/cdc"
+	"github.com/cnlangzi/dbkrab/internal/store"
 )
 
 // ReplayService replays CDC changes from the store
 type ReplayService struct {
-	store   Store
+	store   store.Store
 	handler Handler
 }
 
-// Store interface for replay operations (uses cdc.Change)
-type Store interface {
-	GetLSNs() ([]string, error)
-	GetChangesWithLSN(lsn string) ([]cdc.Change, error)
+// ReplayResult contains the replay statistics
+type ReplayResult struct {
+	TotalLSNs     int
+	TotalChanges  int
+	ProcessedLSNs int
+	FailedLSNs    int
 }
 
 // NewReplayService creates a new ReplayService
-func NewReplayService(store Store, handler Handler) *ReplayService {
+func NewReplayService(store store.Store, handler Handler) *ReplayService {
 	return &ReplayService{
 		store:   store,
 		handler: handler,
@@ -29,32 +32,41 @@ func NewReplayService(store Store, handler Handler) *ReplayService {
 }
 
 // Execute replays all CDC changes from the store in LSN order
-func (r *ReplayService) Execute(ctx context.Context) error {
+func (r *ReplayService) Execute(ctx context.Context) (*ReplayResult, error) {
 	// Get all unique LSNs from store
 	lsns, err := r.store.GetLSNs()
 	if err != nil {
-		return fmt.Errorf("failed to get LSNs: %w", err)
+		return nil, fmt.Errorf("failed to get LSNs: %w", err)
 	}
 
 	if len(lsns) == 0 {
 		slog.Info("no changes to replay")
-		return nil
+		return &ReplayResult{}, nil
 	}
 
 	slog.Info("starting replay", "lsn_count", len(lsns))
+
+	result := &ReplayResult{TotalLSNs: len(lsns)}
 
 	// Process each LSN in order
 	for i, lsn := range lsns {
 		if err := r.replayLSN(ctx, lsn); err != nil {
 			slog.Error("failed to replay LSN", "lsn", lsn, "index", i+1, "total", len(lsns), "error", err)
-			return fmt.Errorf("replay LSN %s: %w", lsn, err)
+			result.FailedLSNs++
+			continue
 		}
 
+		result.ProcessedLSNs++
 		slog.Debug("replayed LSN", "lsn", lsn, "index", i+1, "total", len(lsns))
 	}
 
-	slog.Info("replay completed", "total_lsns", len(lsns))
-	return nil
+	slog.Info("replay completed",
+		"total_lsns", result.TotalLSNs,
+		"processed", result.ProcessedLSNs,
+		"failed", result.FailedLSNs,
+		"total_changes", result.TotalChanges)
+
+	return result, nil
 }
 
 // replayLSN replays all changes for a specific LSN

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -110,7 +110,8 @@ func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *Repla
 	}
 
 	// Handle the transaction
-	if err := r.handler.Handle(ctx, tx); err != nil {
+	batchCtx := NewBatchContext()
+	if err := r.handler.Handle(ctx, tx, batchCtx); err != nil {
 		return fmt.Errorf("handle transaction %s: %w", tx.ID, err)
 	}
 

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/cnlangzi/dbkrab/internal/cdc"
+	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/store"
 )
 
@@ -96,15 +96,15 @@ func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *Repla
 	return nil
 }
 
-// buildTransaction builds a core.Transaction from cdc.Change slice
+// buildTransaction builds a core.Transaction from core.Change slice
 // It groups changes by transaction ID and filters out UPDATE_BEFORE operations
-func (r *ReplayService) buildTransaction(changes []cdc.Change) *Transaction {
+func (r *ReplayService) buildTransaction(changes []core.Change) *Transaction {
 	// Group by transaction ID, filtering out UPDATE_BEFORE
 	txMap := make(map[string]*Transaction)
 
 	for _, c := range changes {
 		// Filter out UPDATE_BEFORE operations (operation == 3)
-		if c.Operation == 3 { // OpUpdateBefore
+		if c.Operation == core.OpUpdateBefore { // OpUpdateBefore
 			slog.Debug("buildTransaction: silently dropping UPDATE_BEFORE change",
 				"table", c.Table,
 				"tx_id", c.TransactionID,
@@ -118,9 +118,8 @@ func (r *ReplayService) buildTransaction(changes []cdc.Change) *Transaction {
 			txMap[c.TransactionID] = tx
 		}
 
-		// Convert cdc.Change to core.Change
-		coreChange := ConvertToCoreChange(c)
-		tx.AddChange(coreChange)
+		// Already core.Change, add directly
+		tx.AddChange(c)
 	}
 
 	// Convert map to slice - should only have one transaction per LSN
@@ -139,18 +138,5 @@ func (r *ReplayService) buildTransaction(changes []cdc.Change) *Transaction {
 	return &Transaction{
 		ID:      "",
 		Changes: []Change{},
-	}
-}
-
-// ConvertToCoreChange converts cdc.Change to core.Change
-func ConvertToCoreChange(c cdc.Change) Change {
-	return Change{
-		Table:         c.Table,
-		TransactionID: c.TransactionID,
-		LSN:           c.LSN,
-		Operation:     Operation(c.Operation),
-		Data:          c.Data,
-		CommitTime:    c.CommitTime,
-		ID:            "", // ID will be computed if needed
 	}
 }

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -50,7 +50,7 @@ func (r *ReplayService) Execute(ctx context.Context) (*ReplayResult, error) {
 
 	// Process each LSN in order
 	for i, lsn := range lsns {
-		if err := r.replayLSN(ctx, lsn); err != nil {
+		if err := r.replayLSN(ctx, lsn, result); err != nil {
 			slog.Error("failed to replay LSN", "lsn", lsn, "index", i+1, "total", len(lsns), "error", err)
 			result.FailedLSNs++
 			continue
@@ -70,7 +70,7 @@ func (r *ReplayService) Execute(ctx context.Context) (*ReplayResult, error) {
 }
 
 // replayLSN replays all changes for a specific LSN
-func (r *ReplayService) replayLSN(ctx context.Context, lsn string) error {
+func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *ReplayResult) error {
 	// Get all changes for this LSN
 	changes, err := r.store.GetChangesWithLSN(lsn)
 	if err != nil {
@@ -81,6 +81,9 @@ func (r *ReplayService) replayLSN(ctx context.Context, lsn string) error {
 		slog.Debug("no changes for LSN", "lsn", lsn)
 		return nil
 	}
+
+	// Count total changes
+	result.TotalChanges += len(changes)
 
 	// Build transaction from changes
 	tx := r.buildTransaction(changes)

--- a/internal/core/replay.go
+++ b/internal/core/replay.go
@@ -50,6 +50,17 @@ func (r *ReplayService) Execute(ctx context.Context) (*ReplayResult, error) {
 
 	// Process each LSN in order
 	for i, lsn := range lsns {
+		// Honor caller cancellation between LSNs
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			slog.Warn("replay cancelled",
+				"error", ctxErr,
+				"processed", result.ProcessedLSNs,
+				"failed", result.FailedLSNs,
+				"total", len(lsns),
+			)
+			return result, ctxErr
+		}
+
 		if err := r.replayLSN(ctx, lsn, result); err != nil {
 			slog.Error("failed to replay LSN", "lsn", lsn, "index", i+1, "total", len(lsns), "error", err)
 			result.FailedLSNs++
@@ -87,6 +98,12 @@ func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *Repla
 
 	// Build transaction from changes
 	tx := r.buildTransaction(changes)
+
+	// Skip if transaction has no changes (all were UPDATE_BEFORE)
+	if len(tx.Changes) == 0 {
+		slog.Debug("replayLSN: skip LSN with no valid changes after filtering UPDATE_BEFORE", "lsn", lsn)
+		return nil
+	}
 
 	// Handle the transaction
 	if err := r.handler.Handle(ctx, tx); err != nil {

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cnlangzi/dbkrab/internal/cdc"
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/sqliteutil"
 	"github.com/cnlangzi/dbkrab/internal/store"
@@ -280,6 +281,119 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 	}
 
 	return results, rows.Err()
+}
+
+// GetLSNs returns all unique LSNs from the store, ordered by LSN
+func (s *Store) GetLSNs() ([]string, error) {
+	rows, err := s.db.Reader.Query(`
+		SELECT DISTINCT lsn
+		FROM changes
+		WHERE lsn IS NOT NULL AND lsn != ''
+		ORDER BY lsn ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("rows.Close error", "error", err)
+		}
+	}()
+
+	var lsns []string
+	for rows.Next() {
+		var lsn string
+		if err := rows.Scan(&lsn); err != nil {
+			return nil, err
+		}
+		lsns = append(lsns, lsn)
+	}
+
+	return lsns, rows.Err()
+}
+
+// GetChangesWithLSN returns all changes for a specific LSN, converted to cdc.Change format
+func (s *Store) GetChangesWithLSN(lsn string) ([]cdc.Change, error) {
+	rows, err := s.db.Reader.Query(`
+		SELECT id, transaction_id, table_name, operation, data, lsn, changed_at
+		FROM changes
+		WHERE lsn = ?
+		ORDER BY id
+	`, lsn)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("rows.Close error", "error", err)
+		}
+	}()
+
+	var changes []cdc.Change
+	for rows.Next() {
+		var id, txID, tableName, operation, dataStr, lsnStr string
+		var changedAt interface{}
+
+		if err := rows.Scan(&id, &txID, &tableName, &operation, &dataStr, &lsnStr, &changedAt); err != nil {
+			return nil, err
+		}
+
+		// Convert operation string to int
+		op := operationStringToInt(operation)
+
+		// Convert LSN hex string to bytes
+		var lsnBytes []byte
+		if lsnStr != "" && len(lsnStr) > 2 {
+			// Remove "0x" prefix if present
+			hexStr := lsnStr
+			if len(hexStr) >= 2 && hexStr[:2] == "0x" {
+				hexStr = hexStr[2:]
+			}
+			lsnBytes, _ = hex.DecodeString(hexStr)
+		}
+
+		// Parse JSON data to map
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(dataStr), &data); err != nil {
+			data = make(map[string]interface{})
+		}
+
+		// Parse commit time
+		var commitTime time.Time
+		if changedAt != nil {
+			if t, ok := changedAt.(time.Time); ok {
+				commitTime = t
+			}
+		}
+
+		changes = append(changes, cdc.Change{
+			Table:         tableName,
+			TransactionID: txID,
+			LSN:           lsnBytes,
+			Operation:     op,
+			CommitTime:    commitTime,
+			Data:          data,
+		})
+	}
+
+	return changes, rows.Err()
+}
+
+// operationStringToInt converts operation string to int
+// INSERT→2, DELETE→1, UPDATE_BEFORE→3, UPDATE_AFTER→4
+func operationStringToInt(op string) int {
+	switch op {
+	case "INSERT":
+		return 2
+	case "DELETE":
+		return 1
+	case "UPDATE_BEFORE":
+		return 3
+	case "UPDATE_AFTER":
+		return 4
+	default:
+		return 0
+	}
 }
 
 // Ensure the Store implements the store.Store interface

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -392,7 +392,7 @@ func operationStringToInt(op string) int {
 	case "UPDATE_AFTER":
 		return 4
 	default:
-		return 0
+		return 2 // Default to INSERT for safety
 	}
 }
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -347,12 +347,18 @@ func (s *Store) GetChangesWithLSN(lsn string) ([]core.Change, error) {
 			if len(hexStr) >= 2 && hexStr[:2] == "0x" {
 				hexStr = hexStr[2:]
 			}
-			lsnBytes, _ = hex.DecodeString(hexStr)
+			if decoded, err := hex.DecodeString(hexStr); err != nil {
+				slog.Warn("failed to decode LSN hex", "lsn", lsnStr, "error", err)
+				lsnBytes = nil
+			} else {
+				lsnBytes = decoded
+			}
 		}
 
 		// Parse JSON data to map
 		var data map[string]interface{}
 		if err := json.Unmarshal([]byte(dataStr), &data); err != nil {
+			slog.Warn("failed to parse JSON data", "id", id, "lsn", lsnStr, "error", err)
 			data = make(map[string]interface{})
 		}
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cnlangzi/dbkrab/internal/cdc"
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/sqliteutil"
 	"github.com/cnlangzi/dbkrab/internal/store"
@@ -312,8 +311,8 @@ func (s *Store) GetLSNs() ([]string, error) {
 	return lsns, rows.Err()
 }
 
-// GetChangesWithLSN returns all changes for a specific LSN, converted to cdc.Change format
-func (s *Store) GetChangesWithLSN(lsn string) ([]cdc.Change, error) {
+// GetChangesWithLSN returns all changes for a specific LSN, as core.Change
+func (s *Store) GetChangesWithLSN(lsn string) ([]core.Change, error) {
 	rows, err := s.db.Reader.Query(`
 		SELECT id, transaction_id, table_name, operation, data, lsn, changed_at
 		FROM changes
@@ -329,7 +328,7 @@ func (s *Store) GetChangesWithLSN(lsn string) ([]cdc.Change, error) {
 		}
 	}()
 
-	var changes []cdc.Change
+	var changes []core.Change
 	for rows.Next() {
 		var id, txID, tableName, operation, dataStr, lsnStr string
 		var changedAt interface{}
@@ -338,13 +337,12 @@ func (s *Store) GetChangesWithLSN(lsn string) ([]cdc.Change, error) {
 			return nil, err
 		}
 
-		// Convert operation string to int
-		op := operationStringToInt(operation)
+		// Convert operation string to core.Operation
+		op := core.Operation(operationStringToInt(operation))
 
 		// Convert LSN hex string to bytes
 		var lsnBytes []byte
 		if lsnStr != "" && len(lsnStr) > 2 {
-			// Remove "0x" prefix if present
 			hexStr := lsnStr
 			if len(hexStr) >= 2 && hexStr[:2] == "0x" {
 				hexStr = hexStr[2:]
@@ -366,13 +364,14 @@ func (s *Store) GetChangesWithLSN(lsn string) ([]cdc.Change, error) {
 			}
 		}
 
-		changes = append(changes, cdc.Change{
+		changes = append(changes, core.Change{
 			Table:         tableName,
 			TransactionID: txID,
 			LSN:           lsnBytes,
 			Operation:     op,
 			CommitTime:    commitTime,
 			Data:          data,
+			ID:            id, // Use the stored ID
 		})
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/cnlangzi/dbkrab/internal/cdc"
 	"github.com/cnlangzi/dbkrab/internal/core"
 )
 
@@ -32,4 +33,10 @@ type Store interface {
 
 	// Close closes the store and releases resources
 	Close() error
+
+	// GetLSNs returns all unique LSNs from the store, ordered by LSN
+	GetLSNs() ([]string, error)
+
+	// GetChangesWithLSN returns all changes for a specific LSN, converted to cdc.Change format
+	GetChangesWithLSN(lsn string) ([]cdc.Change, error)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"github.com/cnlangzi/dbkrab/internal/cdc"
 	"github.com/cnlangzi/dbkrab/internal/core"
 )
 
@@ -37,6 +36,6 @@ type Store interface {
 	// GetLSNs returns all unique LSNs from the store, ordered by LSN
 	GetLSNs() ([]string, error)
 
-	// GetChangesWithLSN returns all changes for a specific LSN, converted to cdc.Change format
-	GetChangesWithLSN(lsn string) ([]cdc.Change, error)
+	// GetChangesWithLSN returns all changes for a specific LSN, as core.Change
+	GetChangesWithLSN(lsn string) ([]core.Change, error)
 }


### PR DESCRIPTION
## Summary

Add a replay functionality that allows reprocessing historical CDC changes from the local `changes` table without re-fetching from MSSQL CDC.

## Changes

- Add `GetLSNs()` and `GetChangesWithLSN()` to store interface
- Implement methods in sqlite store with type conversions
- Add ReplayService in core for replaying historical changes
- Type consistency: `cdc.Change` used throughout pipeline

## Technical Details

- `GetChangesWithLSN` returns `cdc.Change` type to match MSSQL fetch output
- Process by LSN batches to maintain transaction integrity
- Reuse `handler.Handle()` - no duplicate processing logic

## Files Changed

- `internal/store/store.go`
- `internal/store/sqlite/store.go`
- `internal/core/replay.go`

Closes #170

## Summary by Sourcery

Add support for replaying stored CDC changes in LSN order using a new core replay service and corresponding store APIs.

New Features:
- Introduce a ReplayService in the core package to reprocess historical CDC changes from the local store.
- Expose store methods to fetch distinct LSNs and their associated changes in a CDC-compatible format for replay.

Enhancements:
- Normalize change representation by converting stored SQLite change rows into the shared cdc.Change type for use across the pipeline.