### PR TITLE
feat(monitor): add Monitor dashboard (issue #173)

### DIFF
--- a/cmd/app/dashboard/layouts/dashboard.html
+++ b/cmd/app/dashboard/layouts/dashboard.html
@@ -172,6 +172,37 @@
                     </svg>
                     <span>Sinks</span>
                 </a>
+
+                <!-- Monitor Section (collapsible) -->
+                <div class="mt-2">
+                    <button onclick="toggleMonitorMenu()" 
+                            class="flex items-center justify-between w-full px-4 py-3 text-textMuted hover:bg-surface hover:text-text transition-colors">
+                        <div class="flex items-center gap-3">
+                            <!-- Monitor Icon -->
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                            </svg>
+                            <span>Monitor</span>
+                        </div>
+                        <svg id="monitor-chevron" class="w-4 h-4 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                    </button>
+                    <div id="monitor-submenu" class="hidden pl-4">
+                        <a href="/monitor/batches" data-tab="monitor-batches"
+                           class="flex items-center gap-3 px-4 py-2 text-textMuted hover:bg-surface hover:text-text transition-colors text-sm sidebar-link">
+                            <span>Batch</span>
+                        </a>
+                        <a href="/monitor/skills" data-tab="monitor-skills"
+                           class="flex items-center gap-3 px-4 py-2 text-textMuted hover:bg-surface hover:text-text transition-colors text-sm sidebar-link">
+                            <span>Skills</span>
+                        </a>
+                        <a href="/monitor/sinks" data-tab="monitor-sinks"
+                           class="flex items-center gap-3 px-4 py-2 text-textMuted hover:bg-surface hover:text-text transition-colors text-sm sidebar-link">
+                            <span>Sinks</span>
+                        </a>
+                    </div>
+                </div>
             </nav>
 
             <!-- Footer -->
@@ -238,6 +269,14 @@
         document.addEventListener('DOMContentLoaded', highlightActiveTab);
         // Also run after HTMX swaps
         document.body.addEventListener('htmx:afterSwap', highlightActiveTab);
+
+        // Toggle Monitor submenu
+        function toggleMonitorMenu() {
+            const submenu = document.getElementById('monitor-submenu');
+            const chevron = document.getElementById('monitor-chevron');
+            submenu.classList.toggle('hidden');
+            chevron.classList.toggle('rotate-180');
+        }
     </script>
 </body>
 </html>

--- a/cmd/app/dashboard/pages/monitor/batches.html
+++ b/cmd/app/dashboard/pages/monitor/batches.html
@@ -1,0 +1,100 @@
+<!--layout:dashboard-->
+{{ define "content" }}
+<div class="space-y-6">
+    <h2 class="text-2xl font-bold text-text">Monitor - Batch</h2>
+    
+    <!-- Filters -->
+    <div class="bg-surface rounded-xl shadow-lg p-6 border border-border">
+        <form class="flex flex-wrap gap-4 items-end">
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Limit</label>
+                <select id="limit" class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+                    <option value="25">25</option>
+                    <option value="50" selected>50</option>
+                    <option value="100">100</option>
+                </select>
+            </div>
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Since</label>
+                <select id="since" class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+                    <option value="1">Last 1 day</option>
+                    <option value="7" selected>Last 7 days</option>
+                    <option value="30">Last 30 days</option>
+                </select>
+            </div>
+            <button type="button" onclick="loadBatches()" 
+                    class="bg-primary hover:bg-primaryHover text-white px-4 py-2 rounded-lg transition-colors">
+                Refresh
+            </button>
+        </form>
+    </div>
+
+    <!-- Batch Logs Table -->
+    <div class="bg-surface rounded-xl shadow-lg border border-border overflow-hidden">
+        <div id="batches-container" class="overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-bg text-textMuted text-left">
+                    <tr>
+                        <th class="px-4 py-3 font-medium">Batch ID</th>
+                        <th class="px-4 py-3 font-medium">Fetched Rows</th>
+                        <th class="px-4 py-3 font-medium">TX Count</th>
+                        <th class="px-4 py-3 font-medium">DLQ Count</th>
+                        <th class="px-4 py-3 font-medium">Duration (ms)</th>
+                        <th class="px-4 py-3 font-medium">Status</th>
+                        <th class="px-4 py-3 font-medium">Created At</th>
+                    </tr>
+                </thead>
+                <tbody id="batches-tbody" class="divide-y divide-border">
+                    <tr>
+                        <td colspan="7" class="px-4 py-8 text-center text-textMuted">
+                            Loading...
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Load on page load
+    document.addEventListener('DOMContentLoaded', loadBatches);
+
+    function loadBatches() {
+        const limit = document.getElementById('limit').value;
+        const since = document.getElementById('since').value;
+        const url = `/api/monitor/batches?limit=${limit}&since=${since}`;
+        
+        fetch(url)
+            .then(r => r.json())
+            .then(data => {
+                const tbody = document.getElementById('batches-tbody');
+                if (!data.success || !data.logs || data.logs.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="7" class="px-4 py-8 text-center text-textMuted">No data</td></tr>';
+                    return;
+                }
+                tbody.innerHTML = data.logs.map(log => `
+                    <tr class="hover:bg-surfaceHover transition-colors">
+                        <td class="px-4 py-3 text-text font-mono text-sm">${log.batch_id || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.fetched_rows || 0}</td>
+                        <td class="px-4 py-3 text-text">${log.tx_count || 0}</td>
+                        <td class="px-4 py-3 text-text">${log.dlq_count || 0}</td>
+                        <td class="px-4 py-3 text-text">${log.duration_ms || 0}</td>
+                        <td class="px-4 py-3">
+                            <span class="px-2 py-1 rounded text-xs font-medium ${
+                                log.status === 'SUCCESS' ? 'bg-success/20 text-success' :
+                                log.status === 'PARTIAL' ? 'bg-warning/20 text-warning' :
+                                'bg-error/20 text-error'
+                            }">${log.status || ''}</span>
+                        </td>
+                        <td class="px-4 py-3 text-textMuted text-sm">${log.created_at ? new Date(log.created_at).toLocaleString() : ''}</td>
+                    </tr>
+                `).join('');
+            })
+            .catch(err => {
+                document.getElementById('batches-tbody').innerHTML = 
+                    '<tr><td colspan="7" class="px-4 py-8 text-center text-error">Error loading data</td></tr>';
+            });
+    }
+</script>
+{{ end }}

--- a/cmd/app/dashboard/pages/monitor/sinks.html
+++ b/cmd/app/dashboard/pages/monitor/sinks.html
@@ -1,0 +1,113 @@
+<!--layout:dashboard-->
+{{ define "content" }}
+<div class="space-y-6">
+    <h2 class="text-2xl font-bold text-text">Monitor - Sinks</h2>
+    
+    <!-- Filters -->
+    <div class="bg-surface rounded-xl shadow-lg p-6 border border-border">
+        <form class="flex flex-wrap gap-4 items-end">
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Sink Name</label>
+                <input type="text" id="sinkName" placeholder="Filter by sink name"
+                       class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+            </div>
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Database</label>
+                <input type="text" id="database" placeholder="Filter by database/table"
+                       class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+            </div>
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Limit</label>
+                <select id="limit" class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+                    <option value="25">25</option>
+                    <option value="50" selected>50</option>
+                    <option value="100">100</option>
+                </select>
+            </div>
+            <button type="button" onclick="loadSinks()" 
+                    class="bg-primary hover:bg-primaryHover text-white px-4 py-2 rounded-lg transition-colors">
+                Refresh
+            </button>
+        </form>
+    </div>
+
+    <!-- Sink Logs Table -->
+    <div class="bg-surface rounded-xl shadow-lg border border-border overflow-hidden">
+        <div id="sinks-container" class="overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-bg text-textMuted text-left">
+                    <tr>
+                        <th class="px-4 py-3 font-medium">Batch ID</th>
+                        <th class="px-4 py-3 font-medium">Skill</th>
+                        <th class="px-4 py-3 font-medium">Sink</th>
+                        <th class="px-4 py-3 font-medium">Output Table</th>
+                        <th class="px-4 py-3 font-medium">Operation</th>
+                        <th class="px-4 py-3 font-medium">Rows</th>
+                        <th class="px-4 py-3 font-medium">Status</th>
+                        <th class="px-4 py-3 font-medium">Duration (ms)</th>
+                        <th class="px-4 py-3 font-medium">Error</th>
+                        <th class="px-4 py-3 font-medium">Created At</th>
+                    </tr>
+                </thead>
+                <tbody id="sinks-tbody" class="divide-y divide-border">
+                    <tr>
+                        <td colspan="10" class="px-4 py-8 text-center text-textMuted">
+                            Loading...
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', loadSinks);
+
+    function loadSinks() {
+        const sinkName = document.getElementById('sinkName').value;
+        const database = document.getElementById('database').value;
+        const limit = document.getElementById('limit').value;
+        let url = `/api/monitor/sinks?limit=${limit}`;
+        if (sinkName) {
+            url += `&sink_name=${encodeURIComponent(sinkName)}`;
+        }
+        if (database) {
+            url += `&database=${encodeURIComponent(database)}`;
+        }
+        
+        fetch(url)
+            .then(r => r.json())
+            .then(data => {
+                const tbody = document.getElementById('sinks-tbody');
+                if (!data.success || !data.logs || data.logs.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="10" class="px-4 py-8 text-center text-textMuted">No data</td></tr>';
+                    return;
+                }
+                tbody.innerHTML = data.logs.map(log => `
+                    <tr class="hover:bg-surfaceHover transition-colors">
+                        <td class="px-4 py-3 text-text font-mono text-sm">${log.batch_id || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.skill_name || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.sink_name || ''}</td>
+                        <td class="px-4 py-3 text-text font-mono text-sm">${log.output_table || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.operation || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.rows_written || 0}</td>
+                        <td class="px-4 py-3">
+                            <span class="px-2 py-1 rounded text-xs font-medium ${
+                                log.status === 'SUCCESS' ? 'bg-success/20 text-success' :
+                                'bg-error/20 text-error'
+                            }">${log.status || ''}</span>
+                        </td>
+                        <td class="px-4 py-3 text-text">${log.duration_ms || 0}</td>
+                        <td class="px-4 py-3 text-error text-sm max-w-xs truncate" title="${log.error_message || ''}">${log.error_message || '-'}</td>
+                        <td class="px-4 py-3 text-textMuted text-sm">${log.created_at ? new Date(log.created_at).toLocaleString() : ''}</td>
+                    </tr>
+                `).join('');
+            })
+            .catch(err => {
+                document.getElementById('sinks-tbody').innerHTML = 
+                    '<tr><td colspan="10" class="px-4 py-8 text-center text-error">Error loading data</td></tr>';
+            });
+    }
+</script>
+{{ end }}

--- a/cmd/app/dashboard/pages/monitor/skills.html
+++ b/cmd/app/dashboard/pages/monitor/skills.html
@@ -1,0 +1,102 @@
+<!--layout:dashboard-->
+{{ define "content" }}
+<div class="space-y-6">
+    <h2 class="text-2xl font-bold text-text">Monitor - Skills</h2>
+    
+    <!-- Filters -->
+    <div class="bg-surface rounded-xl shadow-lg p-6 border border-border">
+        <form class="flex flex-wrap gap-4 items-end">
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Skill ID</label>
+                <input type="text" id="skillId" placeholder="Filter by skill ID"
+                       class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+            </div>
+            <div>
+                <label class="block text-textMuted text-sm mb-1">Limit</label>
+                <select id="limit" class="bg-bg border border-border rounded-lg px-3 py-2 text-text">
+                    <option value="25">25</option>
+                    <option value="50" selected>50</option>
+                    <option value="100">100</option>
+                </select>
+            </div>
+            <button type="button" onclick="loadSkills()" 
+                    class="bg-primary hover:bg-primaryHover text-white px-4 py-2 rounded-lg transition-colors">
+                Refresh
+            </button>
+        </form>
+    </div>
+
+    <!-- Skill Logs Table -->
+    <div class="bg-surface rounded-xl shadow-lg border border-border overflow-hidden">
+        <div id="skills-container" class="overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-bg text-textMuted text-left">
+                    <tr>
+                        <th class="px-4 py-3 font-medium">Batch ID</th>
+                        <th class="px-4 py-3 font-medium">Skill ID</th>
+                        <th class="px-4 py-3 font-medium">Skill Name</th>
+                        <th class="px-4 py-3 font-medium">Operation</th>
+                        <th class="px-4 py-3 font-medium">Rows</th>
+                        <th class="px-4 py-3 font-medium">Status</th>
+                        <th class="px-4 py-3 font-medium">Duration (ms)</th>
+                        <th class="px-4 py-3 font-medium">Error</th>
+                        <th class="px-4 py-3 font-medium">Created At</th>
+                    </tr>
+                </thead>
+                <tbody id="skills-tbody" class="divide-y divide-border">
+                    <tr>
+                        <td colspan="9" class="px-4 py-8 text-center text-textMuted">
+                            Loading...
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', loadSkills);
+
+    function loadSkills() {
+        const skillId = document.getElementById('skillId').value;
+        const limit = document.getElementById('limit').value;
+        let url = `/api/monitor/skills?limit=${limit}`;
+        if (skillId) {
+            url += `&skill_id=${encodeURIComponent(skillId)}`;
+        }
+        
+        fetch(url)
+            .then(r => r.json())
+            .then(data => {
+                const tbody = document.getElementById('skills-tbody');
+                if (!data.success || !data.logs || data.logs.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="9" class="px-4 py-8 text-center text-textMuted">No data</td></tr>';
+                    return;
+                }
+                tbody.innerHTML = data.logs.map(log => `
+                    <tr class="hover:bg-surfaceHover transition-colors">
+                        <td class="px-4 py-3 text-text font-mono text-sm">${log.batch_id || ''}</td>
+                        <td class="px-4 py-3 text-text font-mono text-sm">${log.skill_id || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.skill_name || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.operation || ''}</td>
+                        <td class="px-4 py-3 text-text">${log.rows_processed || 0}</td>
+                        <td class="px-4 py-3">
+                            <span class="px-2 py-1 rounded text-xs font-medium ${
+                                log.status === 'SUCCESS' ? 'bg-success/20 text-success' :
+                                'bg-error/20 text-error'
+                            }">${log.status || ''}</span>
+                        </td>
+                        <td class="px-4 py-3 text-text">${log.duration_ms || 0}</td>
+                        <td class="px-4 py-3 text-error text-sm max-w-xs truncate" title="${log.error_message || ''}">${log.error_message || '-'}</td>
+                        <td class="px-4 py-3 text-textMuted text-sm">${log.created_at ? new Date(log.created_at).toLocaleString() : ''}</td>
+                    </tr>
+                `).join('');
+            })
+            .catch(err => {
+                document.getElementById('skills-tbody').innerHTML = 
+                    '<tr><td colspan="9" class="px-4 py-8 text-center text-error">Error loading data</td></tr>';
+            });
+    }
+</script>
+{{ end }}

--- a/cmd/app/dashboard/pages/sinks.html
+++ b/cmd/app/dashboard/pages/sinks.html
@@ -3,8 +3,18 @@
 <div class="max-w-7xl mx-auto">
     <!-- Page Header -->
     <div class="mb-6">
-        <h2 class="text-2xl sm:text-3xl font-bold text-text mb-2">Sinks Browser</h2>
-        <p class="text-sm text-textMuted">Browse and query SQLite sink databases</p>
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-2xl sm:text-3xl font-bold text-text mb-2">Sinks Browser</h2>
+                <p class="text-sm text-textMuted">Browse and query SQLite sink databases</p>
+            </div>
+            <a href="/monitor/sinks" class="text-sm text-primary hover:text-primaryHover flex items-center gap-1">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                </svg>
+                Monitor
+            </a>
+        </div>
     </div>
 
     <!-- Sinks List -->

--- a/cmd/app/dashboard/pages/skills.html
+++ b/cmd/app/dashboard/pages/skills.html
@@ -4,6 +4,12 @@
     <!-- Page Header -->
     <div class="flex items-center justify-between">
         <h1 class="text-2xl font-bold text-text">Skills</h1>
+        <a href="/monitor/skills" class="text-sm text-primary hover:text-primaryHover flex items-center gap-1">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+            </svg>
+            Monitor
+        </a>
     </div>
 
     <!-- Stats Summary -->

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -231,7 +231,7 @@ func main() {
 	if apiPort == 0 {
 		apiPort = 9020 // fallback
 	}
-	apiServer := NewServerWithCDCAndMetrics(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, apiPort, *configPath, cfg, configWatcher, poller)
+	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, poller)
 	go func() {
 		slog.Info("Dashboard starting", "port", apiPort, "url", fmt.Sprintf("http://localhost:%d", apiPort))
 		if err := apiServer.Start(); err != nil {

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cnlangzi/dbkrab/internal/cdcadmin"
 	"github.com/cnlangzi/dbkrab/internal/config"
 	"github.com/cnlangzi/dbkrab/internal/dlq"
+	"github.com/cnlangzi/dbkrab/internal/monitor"
 	"github.com/cnlangzi/dbkrab/internal/sinker"
 	"github.com/cnlangzi/dbkrab/internal/store"
 	"github.com/cnlangzi/dbkrab/plugin"
@@ -43,41 +44,37 @@ type PollMetricsProvider interface {
 
 // Server provides HTTP API for plugin and DLQ management
 type Server struct {
-	manager       *plugin.Manager
-	dlq           *dlq.DLQ
-	cdcAdmin      *cdcadmin.Admin
-	store         store.Store
-	sinkerManager *sinker.Manager
-	port          int
-	app           *xun.App
-	mux           *http.ServeMux
-	configPath    string
-	config        *config.Config
-	configWatcher *config.Watcher
-	sinksRoot     *os.Root // Secure root for sinks directory access
-	skillsPath    string   // Path to SQL skills directory from config
+	manager        *plugin.Manager
+	dlq            *dlq.DLQ
+	cdcAdmin       *cdcadmin.Admin
+	store          store.Store
+	sinkerManager  *sinker.Manager
+	monitorDB      *monitor.DB
+	port           int
+	app            *xun.App
+	mux            *http.ServeMux
+	configPath     string
+	config         *config.Config
+	configWatcher  *config.Watcher
+	sinksRoot      *os.Root // Secure root for sinks directory access
+	skillsPath     string   // Path to SQL skills directory from config
 	metricsProvider PollMetricsProvider // Provides CDC poll metrics
 }
 
-// NewServer creates a new API server
-func NewServer(manager *plugin.Manager, port int) *Server {
-	return &Server{
-		manager: manager,
-		port:    port,
-	}
-}
-
-// NewServerWithDLQ creates a new API server with DLQ support
-func NewServerWithDLQ(manager *plugin.Manager, dlqStore *dlq.DLQ, port int) *Server {
-	return &Server{
-		manager: manager,
-		dlq:     dlqStore,
-		port:    port,
-	}
-}
-
-// NewServerWithCDC creates a new API server with CDC admin support
-func NewServerWithCDC(manager *plugin.Manager, dlqStore *dlq.DLQ, cdcAdmin *cdcadmin.Admin, store store.Store, sinkerMgr *sinker.Manager, port int, configPath string, cfg *config.Config, watcher *config.Watcher) *Server {
+// NewServer creates a new API server with all features
+func NewServer(
+	manager *plugin.Manager,
+	dlqStore *dlq.DLQ,
+	cdcAdmin *cdcadmin.Admin,
+	store store.Store,
+	sinkerMgr *sinker.Manager,
+	monitorDB *monitor.DB,
+	port int,
+	configPath string,
+	cfg *config.Config,
+	watcher *config.Watcher,
+	metricsProvider PollMetricsProvider,
+) *Server {
 	// Get skills path from config, default to ./skills/sql if not configured
 	skillsPath := cfg.Plugins.SQL.Path
 	if skillsPath == "" {
@@ -85,38 +82,17 @@ func NewServerWithCDC(manager *plugin.Manager, dlqStore *dlq.DLQ, cdcAdmin *cdca
 	}
 
 	return &Server{
-		manager:       manager,
-		dlq:           dlqStore,
-		cdcAdmin:      cdcAdmin,
-		store:         store,
-		sinkerManager: sinkerMgr,
-		port:          port,
-		configPath:    configPath,
-		config:        cfg,
-		configWatcher: watcher,
-		skillsPath:    skillsPath,
-	}
-}
-
-// NewServerWithCDCAndMetrics creates a new API server with CDC admin and metrics support
-func NewServerWithCDCAndMetrics(manager *plugin.Manager, dlqStore *dlq.DLQ, cdcAdmin *cdcadmin.Admin, store store.Store, sinkerMgr *sinker.Manager, port int, configPath string, cfg *config.Config, watcher *config.Watcher, metricsProvider PollMetricsProvider) *Server {
-	// Get skills path from config, default to ./skills/sql if not configured
-	skillsPath := cfg.Plugins.SQL.Path
-	if skillsPath == "" {
-		skillsPath = "./skills/sql"
-	}
-
-	return &Server{
-		manager:        manager,
-		dlq:            dlqStore,
-		cdcAdmin:       cdcAdmin,
-		store:          store,
-		sinkerManager:  sinkerMgr,
-		port:           port,
-		configPath:     configPath,
-		config:         cfg,
-		configWatcher:  watcher,
-		skillsPath:     skillsPath,
+		manager:         manager,
+		dlq:             dlqStore,
+		cdcAdmin:        cdcAdmin,
+		store:           store,
+		sinkerManager:   sinkerMgr,
+		monitorDB:       monitorDB,
+		port:            port,
+		configPath:      configPath,
+		config:          cfg,
+		configWatcher:   watcher,
+		skillsPath:      skillsPath,
 		metricsProvider: metricsProvider,
 	}
 }
@@ -238,6 +214,13 @@ func (s *Server) registerAPIRoutes() {
 
 	api.Get("/health", s.handleHealth, xun.WithViewer(&xun.JsonViewer{}))
 	api.Get("/overview", s.handleOverview)
+
+	// Monitor routes
+	if s.monitorDB != nil {
+		api.Get("/monitor/batches", s.handleMonitorBatches, xun.WithViewer(&xun.JsonViewer{}))
+		api.Get("/monitor/skills", s.handleMonitorSkills, xun.WithViewer(&xun.JsonViewer{}))
+		api.Get("/monitor/sinks", s.handleMonitorSinks, xun.WithViewer(&xun.JsonViewer{}))
+	}
 }
 
 // registerPageRoutes registers page routes
@@ -1371,4 +1354,83 @@ func formatFileSize(size int64) string {
 	default:
 		return fmt.Sprintf("%d B", size)
 	}
+}
+
+// handleMonitorBatches handles GET /api/monitor/batches
+func (s *Server) handleMonitorBatches(c *xun.Context) error {
+	if s.monitorDB == nil {
+		return c.View(map[string]any{"success": false, "error": "monitor DB not initialized"})
+	}
+
+	limit := 50
+	if l := c.Request.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	since := time.Now().AddDate(0, 0, -7) // Default: last 7 days
+	if s := c.Request.URL.Query().Get("since"); s != "" {
+		// Try parsing as RFC3339 first
+		if parsed, err := time.Parse(time.RFC3339, s); err == nil {
+			since = parsed
+		} else if days, err := strconv.Atoi(s); err == nil && days > 0 {
+			// Fallback: treat as number of days
+			since = time.Now().AddDate(0, 0, -days)
+		}
+	}
+
+	logs, err := s.monitorDB.ListBatchLogs(limit, since)
+	if err != nil {
+		return c.View(map[string]any{"success": false, "error": err.Error()})
+	}
+
+	return c.View(map[string]any{"success": true, "logs": logs})
+}
+
+// handleMonitorSkills handles GET /api/monitor/skills
+func (s *Server) handleMonitorSkills(c *xun.Context) error {
+	if s.monitorDB == nil {
+		return c.View(map[string]any{"success": false, "error": "monitor DB not initialized"})
+	}
+
+	limit := 50
+	if l := c.Request.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	skillID := c.Request.URL.Query().Get("skill_id")
+
+	logs, err := s.monitorDB.ListSkillLogs(skillID, "", limit)
+	if err != nil {
+		return c.View(map[string]any{"success": false, "error": err.Error()})
+	}
+
+	return c.View(map[string]any{"success": true, "logs": logs})
+}
+
+// handleMonitorSinks handles GET /api/monitor/sinks
+func (s *Server) handleMonitorSinks(c *xun.Context) error {
+	if s.monitorDB == nil {
+		return c.View(map[string]any{"success": false, "error": "monitor DB not initialized"})
+	}
+
+	limit := 50
+	if l := c.Request.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	sinkName := c.Request.URL.Query().Get("sink_name")
+	database := c.Request.URL.Query().Get("database")
+
+	logs, err := s.monitorDB.ListSinkLogs(sinkName, database, limit)
+	if err != nil {
+		return c.View(map[string]any{"success": false, "error": err.Error()})
+	}
+
+	return c.View(map[string]any{"success": true, "logs": logs})
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -260,7 +260,8 @@ func (l *DB) WriteSinkLog(log *SinkLog) error {
 }
 
 // ListBatchLogs retrieves pull logs with optional limit
-func (l *DB) ListBatchLogs(limit int) ([]*BatchLog, error) {
+// ListBatchLogs retrieves batch logs with optional time filter
+func (l *DB) ListBatchLogs(limit int, since time.Time) ([]*BatchLog, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
@@ -271,13 +272,14 @@ func (l *DB) ListBatchLogs(limit int) ([]*BatchLog, error) {
 	query := `
 		SELECT batch_id, fetched_rows, tx_count, dlq_count, duration_ms, status, created_at
 		FROM batch_logs
+		WHERE created_at >= ?
 		ORDER BY created_at DESC
 	`
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
 
-	rows, err := l.db.Reader.Query(query)
+	rows, err := l.db.Reader.Query(query, since)
 	if err != nil {
 		return nil, fmt.Errorf("query batch_logs: %w", err)
 	}
@@ -302,8 +304,9 @@ func (l *DB) ListBatchLogs(limit int) ([]*BatchLog, error) {
 	return logs, rows.Err()
 }
 
-// ListSkillLogs retrieves skill logs for a specific batch_id
-func (l *DB) ListSkillLogs(pullID string, limit int) ([]*SkillLog, error) {
+// ListSkillLogs retrieves skill logs with optional filters
+// skillID filters by specific skill, pullID filters by specific batch
+func (l *DB) ListSkillLogs(skillID string, pullID string, limit int) ([]*SkillLog, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
@@ -315,14 +318,25 @@ func (l *DB) ListSkillLogs(pullID string, limit int) ([]*SkillLog, error) {
 		SELECT batch_id, skill_id, skill_name, operation, rows_processed,
 			   status, error_message, duration_ms, created_at
 		FROM skill_logs
-		WHERE batch_id = ?
-		ORDER BY created_at DESC
+		WHERE 1=1
 	`
+	args := []interface{}{}
+
+	if skillID != "" {
+		query += " AND skill_id = ?"
+		args = append(args, skillID)
+	}
+	if pullID != "" {
+		query += " AND batch_id = ?"
+		args = append(args, pullID)
+	}
+
+	query += " ORDER BY created_at DESC"
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
 
-	rows, err := l.db.Reader.Query(query, pullID)
+	rows, err := l.db.Reader.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query skill_logs: %w", err)
 	}
@@ -351,8 +365,9 @@ func (l *DB) ListSkillLogs(pullID string, limit int) ([]*SkillLog, error) {
 	return logs, rows.Err()
 }
 
-// ListSinkLogs retrieves sink logs for a specific batch_id
-func (l *DB) ListSinkLogs(pullID string, limit int) ([]*SinkLog, error) {
+// ListSinkLogs retrieves sink logs with optional filters
+// sinkName filters by specific sink, database filters by output table
+func (l *DB) ListSinkLogs(sinkName string, database string, limit int) ([]*SinkLog, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
@@ -364,14 +379,25 @@ func (l *DB) ListSinkLogs(pullID string, limit int) ([]*SinkLog, error) {
 		SELECT batch_id, skill_name, sink_name, output_table, operation,
 			   rows_written, status, error_message, duration_ms, created_at
 		FROM sink_logs
-		WHERE batch_id = ?
-		ORDER BY created_at DESC
+		WHERE 1=1
 	`
+	args := []interface{}{}
+
+	if sinkName != "" {
+		query += " AND sink_name = ?"
+		args = append(args, sinkName)
+	}
+	if database != "" {
+		query += " AND output_table = ?"
+		args = append(args, database)
+	}
+
+	query += " ORDER BY created_at DESC"
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
 
-	rows, err := l.db.Reader.Query(query, pullID)
+	rows, err := l.db.Reader.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query sink_logs: %w", err)
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -58,7 +58,7 @@ func TestDB_WriteBatchLog(t *testing.T) {
 	}
 
 	// Verify the log was written
-	logs, err := monitorDB.ListBatchLogs(10)
+	logs, err := monitorDB.ListBatchLogs(10, time.Now().AddDate(0, 0, -1))
 	if err != nil {
 		t.Fatalf("Failed to list pull logs: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestDB_WriteBatchLog_Partial(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListBatchLogs(10)
+	logs, err := monitorDB.ListBatchLogs(10, time.Now().AddDate(0, 0, -1))
 	if err != nil {
 		t.Fatalf("Failed to list pull logs: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestDB_WriteBatchLog_Failed(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListBatchLogs(10)
+	logs, err := monitorDB.ListBatchLogs(10, time.Now().AddDate(0, 0, -1))
 	if err != nil {
 		t.Fatalf("Failed to list pull logs: %v", err)
 	}
@@ -606,7 +606,7 @@ func TestDB_Flush(t *testing.T) {
 	}
 
 	// Read should work after flush
-	logs, err := monitorDB.ListBatchLogs(10)
+	logs, err := monitorDB.ListBatchLogs(10, time.Now().AddDate(0, 0, -1))
 	if err != nil {
 		t.Fatalf("Failed to list pull logs after flush: %v", err)
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -400,7 +400,7 @@ func TestDB_WriteSinkLog(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSinkLogs("", "test-pull-007", 10)
+	logs, err := monitorDB.ListSinkLogs("", "", 10)
 	if err != nil {
 		t.Fatalf("Failed to list sink logs: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestDB_WriteSinkLog_Error(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSinkLogs("", "test-pull-008", 10)
+	logs, err := monitorDB.ListSinkLogs("", "", 10)
 	if err != nil {
 		t.Fatalf("Failed to list sink logs: %v", err)
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -213,7 +213,7 @@ func TestDB_WriteSkillLog(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSkillLogs("test-pull-004", 10)
+	logs, err := monitorDB.ListSkillLogs("", "test-pull-004", 10)
 	if err != nil {
 		t.Fatalf("Failed to list skill logs: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestDB_WriteSkillLog_Skip(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSkillLogs("test-pull-005", 10)
+	logs, err := monitorDB.ListSkillLogs("", "test-pull-005", 10)
 	if err != nil {
 		t.Fatalf("Failed to list skill logs: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestDB_WriteSkillLog_Error(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSkillLogs("test-pull-006", 10)
+	logs, err := monitorDB.ListSkillLogs("", "test-pull-006", 10)
 	if err != nil {
 		t.Fatalf("Failed to list skill logs: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestDB_WriteSinkLog(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSinkLogs("test-pull-007", 10)
+	logs, err := monitorDB.ListSinkLogs("", "test-pull-007", 10)
 	if err != nil {
 		t.Fatalf("Failed to list sink logs: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestDB_WriteSinkLog_Error(t *testing.T) {
 		t.Fatalf("Failed to flush: %v", err)
 	}
 
-	logs, err := monitorDB.ListSinkLogs("test-pull-008", 10)
+	logs, err := monitorDB.ListSinkLogs("", "test-pull-008", 10)
 	if err != nil {
 		t.Fatalf("Failed to list sink logs: %v", err)
 	}


### PR DESCRIPTION
## Summary

Add Monitor section to dashboard for viewing observability logs from monitor.DB.

## Changes

### Backend
- Add monitorDB to Server struct
- Merge multiple NewServer constructors into single unified NewServer
- Add API endpoints: /api/monitor/batches, /api/monitor/skills, /api/monitor/sinks
- Update monitor.DB methods to support flexible filtering

### Frontend
- Add collapsible Monitor menu in sidebar (Batch, Skills, Sinks)
- Add three new pages under /monitor/

Closes #173