### PR TITLE
Surface skill load errors and last successful load time

### DIFF
--- a/cmd/app/dashboard/pages/skills.html
+++ b/cmd/app/dashboard/pages/skills.html
@@ -103,6 +103,9 @@ function renderSkillsList(skills) {
         const statusClass = skill.status === 'error' ? 'bg-error/20 text-error' : 'bg-success/20 text-success';
         const statusText = skill.status === 'error' ? 'Error' : 'Active';
         
+        // Build error message if present
+        const errorHtml = skill.error ? `<p class="text-xs text-error mt-1 truncate" title="${skill.error}">⚠️ ${skill.error}</p>` : '';
+        
         html += `
             <a href="/skills/edit/${skill.id}" class="block p-4 hover:bg-surfaceHover transition-colors">
                 <div class="flex items-start justify-between">
@@ -112,9 +115,10 @@ function renderSkillsList(skills) {
                             <h4 class="text-base font-semibold text-text truncate">${skill.name}</h4>
                         </div>
                         ${skill.description ? `<p class="text-sm text-textMuted truncate">${skill.description}</p>` : ''}
+                        ${errorHtml}
                         <div class="flex items-center gap-3 mt-2 text-xs text-textMuted">
                             <span>📊 ${skill.tables ? skill.tables.length : 0} tables</span>
-                            <span>📄 ${skill.files ? skill.files.length : 0} files</span>
+                            ${skill.load_time ? `<span>🕐 ${skill.load_time}</span>` : ''}
                         </div>
                     </div>
                     <svg class="w-5 h-5 text-textMuted flex-shrink-0 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/cmd/app/skills.go
+++ b/cmd/app/skills.go
@@ -48,7 +48,6 @@ type SkillInfo struct {
 	Status      string   `json:"status"`        // loaded, error, not_loaded
 	Version     string   `json:"version"`
 	LoadTime    string   `json:"load_time,omitempty"`
-	Files       []string `json:"files"`
 	Error       string   `json:"error,omitempty"`
 }
 
@@ -117,15 +116,19 @@ func (s *Server) handleSkillsList(c *xun.Context) error {
 			File:        skill.File,
 			Description: skill.Description,
 			Tables:      skill.On,
-			Status:      "loaded",
-			Files:       []string{skill.File},
 		}
 
-		// Collect SQL files referenced in the skill
-		for _, sink := range skill.Sinks {
-			if sink.SQLFile != "" {
-				skillInfo.Files = append(skillInfo.Files, sink.SQLFile)
-			}
+		// Set status based on Error field
+		if skill.Error != "" {
+			skillInfo.Status = "error"
+			skillInfo.Error = skill.Error
+		} else {
+			skillInfo.Status = "loaded"
+		}
+
+		// Set load time from LastLoadedAt (if available)
+		if !skill.LastLoadedAt.IsZero() {
+			skillInfo.LoadTime = skill.LastLoadedAt.Format("2006-01-02 15:04:05")
 		}
 
 		skills = append(skills, skillInfo)

--- a/plugin/sql/plugin.go
+++ b/plugin/sql/plugin.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -88,10 +89,22 @@ func (p *Plugin) loadAllSkills() error {
 		filePath := filepath.Join(p.watchDir, entry.Name())
 		skill, err := p.loadSkillFile(filePath)
 		if err != nil {
-			slog.Warn("failed to load skill", "file", entry.Name(), "error", err)
+			// Create a placeholder skill with error information
+			id := hashFile(filePath)
+			relPath, _ := filepath.Rel(p.watchDir, filePath)
+			placeholder := &Skill{
+				Id:    id,
+				File:  relPath,
+				Name: strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())),
+				Error: err.Error(),
+			}
+			p.Skills.Set(placeholder)
+			slog.Warn("failed to load skill, stored as placeholder", "file", entry.Name(), "error", err)
 			continue
 		}
 
+		// Set successful load time
+		skill.LastLoadedAt = time.Now()
 		p.Skills.Set(skill)
 	}
 
@@ -294,10 +307,19 @@ func (p *Plugin) checkChanges() {
 
 				skill, err := p.loadSkillFile(path)
 				if err != nil {
-				slog.Warn("failed to reload skill", "path", path, "error", err)
+					// Load failed - look up existing skill and update its Error
+					id := hashFile(path)
+					if existing, ok := p.Skills.Get(id); ok {
+						existing.Error = err.Error()
+						p.Skills.Set(existing)
+					}
+					slog.Warn("failed to reload skill, error stored", "path", path, "error", err)
 					continue
 				}
 
+				// Successful load - clear Error and set LastLoadedAt
+				skill.Error = ""
+				skill.LastLoadedAt = time.Now()
 				p.Skills.Set(skill)
 			slog.Info("skill reloaded", "path", path, "skill_id", skill.Id)
 			} else {

--- a/plugin/sql/types.go
+++ b/plugin/sql/types.go
@@ -79,9 +79,11 @@ type Skill struct {
 	Sinks       []Sink      `yaml:"sinks"`
 	Outputs     map[string][]string `yaml:"-"` // key = output table name, value = field names
 
-	File string `yaml:"-"` // Auto-assigned: relative path from config.plugins.sql.path
-	Id   string `yaml:"-"` // Auto-assigned: SHA256(File)[:12]
-	Raw  string `yaml:"-"` // Auto-assigned: raw YAML content
+	File         string    `yaml:"-"` // Auto-assigned: relative path from config.plugins.sql.path
+	Id           string    `yaml:"-"` // Auto-assigned: SHA256(File)[:12]
+	Raw          string    `yaml:"-"` // Auto-assigned: raw YAML content
+	Error        string    `yaml:"-"` // last load/parsing error message (if any)
+	LastLoadedAt time.Time `yaml:"-"` // last successful load time
 }
 
 // Sink represents a single sink configuration with operation filter


### PR DESCRIPTION
Fixes: #180

What changed:
- Added Error (string) and LastLoadedAt (time.Time) to the Skill struct and wired them through plugin/sql and command handlers.
- loadAllSkills(): on cold-start parse failure a placeholder Skill (Id, File, Name) is stored with Error set so the API/UI can show the failure.
- checkChanges(): on hot-reload failure the existing Skill keeps its functional fields and receives the new Error; on success Error is cleared and LastLoadedAt is updated.
- API (handleSkillsList): removed Files count, and now returns status (loaded/error), error message, and formatted load_time for each skill.
- UI (dashboard/pages/skills.html): removed files count, added error badge/message and last successful load time display (if available).

Why this changed:
- Previously parse/load errors were only logged and not exposed to the UI, so the front-end could not display the built-in error state. Persisting error text and last successful load time makes health and troubleshooting information available without changing runtime behavior of skills.

How to test:
1. Cold-start failure: place an invalid skill YAML and start the server. Confirm the skills list API includes the skill with non-empty error, status="error", and file/name/id populated; UI shows an error badge and the error message.
2. Hot reload failure: modify an existing valid skill so parsing fails; confirm the in-memory skill retains prior fields but now has Error set and UI/API reflect the error. Then fix the file, trigger reload, confirm Error is cleared and load_time (LastLoadedAt) is set and shown.
3. Verify the skills list no longer returns or displays a Files count.
4. Confirm skill execution behavior is unchanged (only metadata is recorded/exposed).

Related: Issue #180. Branch: fix/fix-surface-skill-load-errors-and-last-successful-load-time-

## Summary by Sourcery

Expose skill load/parsing errors and last successful load time through the SQL plugin, API, and dashboard UI for better visibility into skill health.

New Features:
- Persist the last load/parsing error message and last successful load timestamp on each skill and surface them via the skills list API and dashboard.

Enhancements:
- On initial skill loading, store placeholder skills for files that fail to parse so they are visible in the skills list with error details.
- On skill hot-reload, retain existing skill data while updating error state and load timestamp based on reload success or failure.
- Update the skills dashboard to show an error badge/message and last successful load time instead of file counts.