### PR TITLE
fix: change overwrite to partial update instead of full row replace

### DIFF
--- a/internal/sqliteutil/update_test.go
+++ b/internal/sqliteutil/update_test.go
@@ -78,7 +78,7 @@ func TestUpdateInTx_Overwrite_InsertIfNotExists(t *testing.T) {
 	// Create in-memory database
 	db, err := sqlite.Open(ctx, ":memory:")
 	require.NoError(t, err)
-	defer func() { _ = db.Writer.Close() }()
+	defer func() { _ = db.Close() }()
 
 	// Create table
 	createSQL := `CREATE TABLE test_items (
@@ -128,7 +128,7 @@ func TestUpdateInTx_Overwrite_MultipleColumns(t *testing.T) {
 	// Create in-memory database
 	db, err := sqlite.Open(ctx, ":memory:")
 	require.NoError(t, err)
-	defer func() { _ = db.Writer.Close() }()
+	defer func() { _ = db.Close() }()
 
 	// Create table
 	createSQL := `CREATE TABLE test_items (
@@ -184,7 +184,7 @@ func TestUpdateInTx_Skip_ExistingRecord(t *testing.T) {
 
 	db, err := sqlite.Open(ctx, ":memory:")
 	require.NoError(t, err)
-	defer func() { _ = db.Writer.Close() }()
+	defer func() { _ = db.Close() }()
 
 	// Create table
 	_, err = db.Writer.Exec(`CREATE TABLE test_items (id INTEGER PRIMARY KEY, name TEXT)`)
@@ -221,26 +221,24 @@ func TestUpdateInTx_Skip_ExistingRecord(t *testing.T) {
 	assert.Equal(t, "existing", name, "skip should preserve existing record")
 }
 
-// TestUpdateInTx_PlainUpdate_NoInsert verifies that plain UPDATE (empty OnConflict)
-// only updates if record exists, doesn't insert if not.
-// Note: This is the existing behavior - plain UPDATE returns success but 0 rows affected when no record exists.
-func TestUpdateInTx_PlainUpdate_NoInsert(t *testing.T) {
+// TestUpdateInTx_EmptyOnConflict_DefaultsToOverwrite verifies that empty OnConflict
+// defaults to overwrite strategy (which inserts if not exists).
+func TestUpdateInTx_EmptyOnConflict_DefaultsToOverwrite(t *testing.T) {
 	ctx := context.Background()
 
 	db, err := sqlite.Open(ctx, ":memory:")
 	require.NoError(t, err)
-	defer func() { _ = db.Writer.Close() }()
+	defer func() { _ = db.Close() }()
 
 	// Create table
 	_, err = db.Writer.Exec(`CREATE TABLE test_items (id INTEGER PRIMARY KEY, name TEXT)`)
 	require.NoError(t, err)
 
-	// Use plain update (OnConflict = "") - record doesn't exist
-	// This will execute UPDATE but affect 0 rows (no error)
+	// Use empty OnConflict - should default to overwrite (insert if not exists)
 	config := sqliteutil.TableConfig{
 		Output:      "test_items",
 		PrimaryKey:  "id",
-		OnConflict: "", // plain update
+		OnConflict: "", // empty defaults to overwrite
 	}
 	columns := []string{"id", "name"}
 	rows := [][]interface{}{
@@ -251,19 +249,17 @@ func TestUpdateInTx_PlainUpdate_NoInsert(t *testing.T) {
 	require.NoError(t, err)
 
 	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
-	// Should succeed (UPDATE executes without error even if 0 rows affected)
 	require.NoError(t, err)
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	// Verify: record might be inserted (driver dependent) but test documents behavior
-	// This test verifies no panic/crash - behavior is driver dependent
+	// Verify: empty OnConflict defaults to overwrite, so record should be inserted
 	var count int
 	err = db.Writer.QueryRow(`SELECT COUNT(*) FROM test_items`).Scan(&count)
 	require.NoError(t, err)
 
-	// Document the actual behavior (some drivers insert 0, some don't)
-	t.Logf("Plain update with no existing record: inserted %d rows", count)
+	// Empty OnConflict defaults to overwrite, which inserts if not exists
+	assert.Equal(t, 1, count, "empty OnConflict should default to overwrite and insert record")
 }
 
 // TestInsertInTx_Overwrite_PartialUpdate verifies that InsertInTx with overwrite
@@ -273,7 +269,7 @@ func TestInsertInTx_Overwrite_PartialUpdate(t *testing.T) {
 
 	db, err := sqlite.Open(ctx, ":memory:")
 	require.NoError(t, err)
-	defer func() { _ = db.Writer.Close() }()
+	defer func() { _ = db.Close() }()
 
 	// Create table
 	_, err = db.Writer.Exec(`CREATE TABLE test_items (

--- a/internal/sqliteutil/update_test.go
+++ b/internal/sqliteutil/update_test.go
@@ -1,0 +1,292 @@
+package sqliteutil_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/cnlangzi/dbkrab/internal/sqliteutil"
+	"github.com/cnlangzi/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateInTx_Overwrite_PartialUpdate verifies that overwrite strategy
+// only updates provided columns without affecting other columns.
+func TestUpdateInTx_Overwrite_PartialUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	// Create in-memory database
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Create table
+	createSQL := `CREATE TABLE test_items (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		amount REAL,
+		extra_field TEXT
+	)`
+	_, err = db.Writer.Exec(createSQL)
+	require.NoError(t, err)
+
+	// Insert initial record with all fields
+	insertSQL := `INSERT INTO test_items (id, name, amount, extra_field) VALUES (?, ?, ?, ?)`
+	_, err = db.Writer.Exec(insertSQL, 1, "initial_name", 100.0, "should_preserve")
+	require.NoError(t, err)
+
+	// Now use UpdateInTx with overwrite strategy, only updating name
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "overwrite",
+	}
+	columns := []string{"id", "name"}
+	rows := [][]interface{}{
+		{1, "updated_name"},
+	}
+
+	// Execute UpdateInTx within a transaction
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
+	require.NoError(t, err)
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: only name should be updated, extra_field should be preserved
+	var name string
+	var amount float64
+	var extraField string
+	selectSQL := `SELECT name, amount, extra_field FROM test_items WHERE id = ?`
+	err = db.Writer.QueryRow(selectSQL, 1).Scan(&name, &amount, &extraField)
+	require.NoError(t, err)
+
+	assert.Equal(t, "updated_name", name, "name should be updated")
+	assert.Equal(t, 100.0, amount, "amount should be preserved")
+	assert.Equal(t, "should_preserve", extraField, "extra_field should be preserved")
+}
+
+// TestUpdateInTx_Overwrite_InsertIfNotExists verifies that overwrite strategy
+// inserts a new record if it doesn't exist.
+func TestUpdateInTx_Overwrite_InsertIfNotExists(t *testing.T) {
+	ctx := context.Background()
+
+	// Create in-memory database
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Writer.Close() }()
+
+	// Create table
+	createSQL := `CREATE TABLE test_items (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		amount REAL
+	)`
+	_, err = db.Writer.Exec(createSQL)
+	require.NoError(t, err)
+
+	// Use UpdateInTx with overwrite strategy for non-existing record
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "overwrite",
+	}
+	columns := []string{"id", "name", "amount"}
+	rows := [][]interface{}{
+		{1, "new_record", 50.0},
+	}
+
+	// Execute UpdateInTx within a transaction
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
+	require.NoError(t, err)
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: record should be inserted
+	var name string
+	var amount float64
+	selectSQL := `SELECT name, amount FROM test_items WHERE id = ?`
+	err = db.Writer.QueryRow(selectSQL, 1).Scan(&name, &amount)
+	require.NoError(t, err)
+
+	assert.Equal(t, "new_record", name)
+	assert.Equal(t, 50.0, amount)
+}
+
+// TestUpdateInTx_Overwrite_MultipleColumns verifies updating multiple columns at once.
+func TestUpdateInTx_Overwrite_MultipleColumns(t *testing.T) {
+	ctx := context.Background()
+
+	// Create in-memory database
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Writer.Close() }()
+
+	// Create table
+	createSQL := `CREATE TABLE test_items (
+		id INTEGER PRIMARY KEY,
+		field1 TEXT,
+		field2 TEXT,
+		field3 TEXT,
+		preserved TEXT
+	)`
+	_, err = db.Writer.Exec(createSQL)
+	require.NoError(t, err)
+
+	// Insert initial record
+	_, err = db.Writer.Exec(`INSERT INTO test_items (id, field1, field2, field3, preserved) VALUES (?, ?, ?, ?, ?)`,
+		1, "old1", "old2", "old3", "preserved_value")
+	require.NoError(t, err)
+
+	// Update only field1 and field2
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "overwrite",
+	}
+	columns := []string{"id", "field1", "field2"}
+	rows := [][]interface{}{
+		{1, "new1", "new2"},
+	}
+
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: field1 and field2 updated, field3 and preserved unchanged
+	var field1, field2, field3, preserved string
+	err = db.Writer.QueryRow(`SELECT field1, field2, field3, preserved FROM test_items WHERE id = 1`).
+		Scan(&field1, &field2, &field3, &preserved)
+	require.NoError(t, err)
+
+	assert.Equal(t, "new1", field1)
+	assert.Equal(t, "new2", field2)
+	assert.Equal(t, "old3", field3, "field3 should be preserved")
+	assert.Equal(t, "preserved_value", preserved, "preserved should be preserved")
+}
+
+// TestUpdateInTx_Skip_ExistingRecord verifies that skip strategy does nothing
+// if record already exists.
+func TestUpdateInTx_Skip_ExistingRecord(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Writer.Close() }()
+
+	// Create table
+	_, err = db.Writer.Exec(`CREATE TABLE test_items (id INTEGER PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+
+	// Insert initial record
+	_, err = db.Writer.Exec(`INSERT INTO test_items (id, name) VALUES (?, ?)`, 1, "existing")
+	require.NoError(t, err)
+
+	// Try to insert with skip (should do nothing)
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "skip",
+	}
+	columns := []string{"id", "name"}
+	rows := [][]interface{}{
+		{1, "new_name"},
+	}
+
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: original name preserved
+	var name string
+	err = db.Writer.QueryRow(`SELECT name FROM test_items WHERE id = 1`).Scan(&name)
+	require.NoError(t, err)
+
+	assert.Equal(t, "existing", name, "skip should preserve existing record")
+}
+
+// TestUpdateInTx_PlainUpdate_NoInsert verifies that plain UPDATE (empty OnConflict)
+// only updates if record exists, doesn't insert if not.
+// Note: This is the existing behavior - plain UPDATE returns success but 0 rows affected when no record exists.
+func TestUpdateInTx_PlainUpdate_NoInsert(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Writer.Close() }()
+
+	// Create table
+	_, err = db.Writer.Exec(`CREATE TABLE test_items (id INTEGER PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+
+	// Use plain update (OnConflict = "") - record doesn't exist
+	// This will execute UPDATE but affect 0 rows (no error)
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "", // plain update
+	}
+	columns := []string{"id", "name"}
+	rows := [][]interface{}{
+		{1, "new_name"},
+	}
+
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.UpdateInTx(tx, config, columns, rows)
+	// Should succeed (UPDATE executes without error even if 0 rows affected)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: record might be inserted (driver dependent) but test documents behavior
+	// This test verifies no panic/crash - behavior is driver dependent
+	var count int
+	err = db.Writer.QueryRow(`SELECT COUNT(*) FROM test_items`).Scan(&count)
+	require.NoError(t, err)
+
+	// Document the actual behavior (some drivers insert 0, some don't)
+	t.Logf("Plain update with no existing record: inserted %d rows", count)
+}
+
+// mockTx implements sqliteutil.TxExec for testing
+type mockTx struct {
+	*sql.Tx
+	execCalls   []struct {
+		query string
+		args  []any
+	}
+}
+
+func (m *mockTx) Exec(query string, args ...any) (sql.Result, error) {
+	m.execCalls = append(m.execCalls, struct {
+		query string
+		args  []any
+	}{query, args})
+	return &mockResult{}, nil
+}
+
+func (m *mockTx) Commit() error   { return nil }
+func (m *mockTx) Rollback() error { return nil }
+
+type mockResult struct{}
+
+func (m *mockResult) LastInsertId() (int64, error)   { return 0, nil }
+func (m *mockResult) RowsAffected() (int64, error) { return 1, nil }

--- a/internal/sqliteutil/update_test.go
+++ b/internal/sqliteutil/update_test.go
@@ -266,6 +266,61 @@ func TestUpdateInTx_PlainUpdate_NoInsert(t *testing.T) {
 	t.Logf("Plain update with no existing record: inserted %d rows", count)
 }
 
+// TestInsertInTx_Overwrite_PartialUpdate verifies that InsertInTx with overwrite
+// strategy also does partial update when called (not just UpdateInTx).
+func TestInsertInTx_Overwrite_PartialUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlite.Open(ctx, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Writer.Close() }()
+
+	// Create table
+	_, err = db.Writer.Exec(`CREATE TABLE test_items (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		amount REAL,
+		extra_field TEXT
+	)`)
+	require.NoError(t, err)
+
+	// Insert initial record
+	_, err = db.Writer.Exec(`INSERT INTO test_items (id, name, amount, extra_field) VALUES (?, ?, ?, ?)`,
+		1, "initial", 100.0, "preserve_me")
+	require.NoError(t, err)
+
+	// Use InsertInTx with overwrite - only updating name
+	config := sqliteutil.TableConfig{
+		Output:      "test_items",
+		PrimaryKey:  "id",
+		OnConflict: "overwrite",
+	}
+	columns := []string{"id", "name"}
+	rows := [][]interface{}{
+		{1, "updated_via_insert"},
+	}
+
+	tx, err := db.Writer.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	err = sqliteutil.InsertInTx(tx, config, columns, rows)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Verify: name updated, amount and extra_field preserved
+	var name string
+	var amount float64
+	var extraField string
+	err = db.Writer.QueryRow(`SELECT name, amount, extra_field FROM test_items WHERE id = 1`).
+		Scan(&name, &amount, &extraField)
+	require.NoError(t, err)
+
+	assert.Equal(t, "updated_via_insert", name)
+	assert.Equal(t, 100.0, amount, "amount should be preserved")
+	assert.Equal(t, "preserve_me", extraField, "extra_field should be preserved")
+}
+
 // mockTx implements sqliteutil.TxExec for testing
 type mockTx struct {
 	*sql.Tx

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -119,100 +119,164 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 }
 
 // UpdateInTx updates records in table.
+// For "overwrite" strategy:
+//   - If record exists: UPDATE only columns in this sink (preserve other columns)
+//   - If record doesn't exist: INSERT the record
+// This achieves partial update without overwriting the entire row.
 func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interface{}) error {
 	if len(rows) == 0 {
 		return nil
 	}
 
+	pkColumn := config.PrimaryKey
+
 	// Find PK index
 	pkIndex := -1
 	for i, col := range columns {
-		if col == config.PrimaryKey {
+		if col == pkColumn {
 			pkIndex = i
 			break
 		}
 	}
 
 	if pkIndex == -1 {
-		return fmt.Errorf("primary key %s not found", config.PrimaryKey)
+		return fmt.Errorf("primary key %s not found", pkColumn)
 	}
 
 	slog.Debug("sqliteutil.UpdateInTx: starting update",
 		"table", config.Output,
-		"primaryKey", config.PrimaryKey,
+		"primaryKey", pkColumn,
 		"pkIndex", pkIndex,
+		"onConflict", config.OnConflict,
 		"columns", columns,
 		"rows", len(rows))
 
 	for _, row := range rows {
 		pkValue := row[pkIndex]
 
-		var sqlStr string
-		var values []any
-
-		// For UPDATE operations:
-		// - "overwrite" (INSERT OR REPLACE): update if exists, insert if not
-		// - "skip" or "" (INSERT OR IGNORE): do nothing if exists, insert if not
-		// - otherwise: plain UPDATE (does nothing if row doesn't exist)
 		switch config.OnConflict {
 		case "overwrite":
-			// Use INSERT OR REPLACE: inserts if not exists, replaces if exists
-			var placeholders []string
-			for i := range columns {
-				placeholders = append(placeholders, "?")
-				values = append(values, row[i])
+			// "overwrite" strategy:
+			// - If record exists: UPDATE only columns in this sink (preserve other columns)
+			// - If record doesn't exist: INSERT the record
+			// This achieves partial update without overwriting entire row
+
+			// First, try UPDATE (only update columns in this sink, preserve other columns)
+			var setClauses []string
+			var updateValues []any
+			for colIdx, col := range columns {
+				if col == pkColumn {
+					continue // Skip PK in SET clause
+				}
+				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
+				updateValues = append(updateValues, row[colIdx])
 			}
-			sqlStr = fmt.Sprintf("INSERT OR REPLACE INTO %s (%s) VALUES (%s)",
+			updateValues = append(updateValues, pkValue)
+
+			updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
 				config.Output,
-				strings.Join(escapedColumns(columns), ", "),
-				strings.Join(placeholders, ", "))
+				strings.Join(setClauses, ", "),
+				pkColumn)
+
+			slog.Debug("sqliteutil.UpdateInTx: executing update",
+				"table", config.Output,
+				"sql", updateSQL,
+				"pkValue", pkValue)
+			result, err := tx.Exec(updateSQL, updateValues...)
+			if err != nil {
+				slog.Error("sqliteutil.UpdateInTx: update failed",
+					"table", config.Output,
+					"sql", updateSQL,
+					"err", err)
+				return fmt.Errorf("update: %w", err)
+			}
+
+			rowsAffected, _ := result.RowsAffected()
+			if rowsAffected == 0 {
+				// No row exists, INSERT new record
+				var placeholders []string
+				for range columns {
+					placeholders = append(placeholders, "?")
+				}
+				insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+					config.Output,
+					strings.Join(escapedColumns(columns), ", "),
+					strings.Join(placeholders, ", "))
+
+				slog.Debug("sqliteutil.UpdateInTx: executing insert",
+					"table", config.Output,
+					"sql", insertSQL,
+					"pkValue", pkValue)
+				_, err := tx.Exec(insertSQL, row...)
+				if err != nil {
+					slog.Error("sqliteutil.UpdateInTx: insert failed",
+						"table", config.Output,
+						"sql", insertSQL,
+						"err", err)
+					return fmt.Errorf("insert: %w", err)
+				}
+			}
 		case "skip", "":
 			// Use INSERT OR IGNORE: does nothing if row with PK already exists
 			var placeholders []string
+			var values []any
 			for i := range columns {
 				placeholders = append(placeholders, "?")
 				values = append(values, row[i])
 			}
-			sqlStr = fmt.Sprintf("INSERT OR IGNORE INTO %s (%s) VALUES (%s)",
+			sqlStr := fmt.Sprintf("INSERT OR IGNORE INTO %s (%s) VALUES (%s)",
 				config.Output,
 				strings.Join(escapedColumns(columns), ", "),
 				strings.Join(placeholders, ", "))
+
+			slog.Debug("sqliteutil.UpdateInTx: executing insert or ignore",
+				"table", config.Output,
+				"sql", sqlStr,
+				"pkValue", pkValue)
+			normalizedValues := normalizeRowValues(columns, values)
+			_, err := tx.Exec(sqlStr, normalizedValues...)
+			if err != nil {
+				slog.Error("sqliteutil.UpdateInTx: exec failed",
+					"table", config.Output,
+					"sql", sqlStr,
+					"pkValue", pkValue,
+					"err", err)
+				return fmt.Errorf("execute: %w", err)
+			}
 		default:
 			// Plain UPDATE: only updates if row exists
 			var setClauses []string
+			var values []any
 			for i, col := range columns {
-				if col == config.PrimaryKey {
+				if col == pkColumn {
 					continue
 				}
 				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
 				values = append(values, row[i])
 			}
-			sqlStr = fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
+			sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
 				config.Output,
 				strings.Join(setClauses, ", "),
-				config.PrimaryKey)
+				pkColumn)
 			values = append(values, pkValue)
-		}
 
-		slog.Debug("sqliteutil.UpdateInTx: executing",
-			"table", config.Output,
-			"sql", sqlStr,
-			"pkValue", pkValue,
-			"valuesCount", len(values))
-
-		// Pass values directly - driver handles time.Time serialization
-		normalizedValues := normalizeRowValues(columns, values)
-		result, err := tx.Exec(sqlStr, normalizedValues...)
-		if err != nil {
-			slog.Error("sqliteutil.UpdateInTx: exec failed",
+			slog.Debug("sqliteutil.UpdateInTx: executing plain update",
 				"table", config.Output,
 				"sql", sqlStr,
 				"pkValue", pkValue,
-				"err", err)
-			return fmt.Errorf("execute: %w", err)
-		}
+				"valuesCount", len(values))
 
-		if result != nil {
+			normalizedValues := normalizeRowValues(columns, values)
+			result, err := tx.Exec(sqlStr, normalizedValues...)
+			if err != nil {
+				slog.Error("sqliteutil.UpdateInTx: exec failed",
+					"table", config.Output,
+					"sql", sqlStr,
+					"pkValue", pkValue,
+					"err", err)
+				return fmt.Errorf("execute: %w", err)
+			}
+
 			rowsAffected, _ := result.RowsAffected()
 			slog.Debug("sqliteutil.UpdateInTx: rows affected",
 				"table", config.Output,
@@ -281,8 +345,8 @@ func DeleteInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 
 // TableConfig holds configuration for table operations.
 type TableConfig struct {
-	Output     string
-	PrimaryKey string
+	Output      string
+	PrimaryKey  string
 	OnConflict string // "overwrite", "skip", or ""
 }
 

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -105,7 +105,13 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 	}
 
 	for _, row := range rows {
-		switch config.OnConflict {
+		// Default to overwrite if not specified or invalid
+		onConflict := config.OnConflict
+		if onConflict != "overwrite" && onConflict != "skip" {
+			onConflict = "overwrite"
+		}
+
+		switch onConflict {
 		case "overwrite":
 			// "overwrite" strategy: partial update
 			// - If record exists: UPDATE only provided columns (preserve other columns)
@@ -239,7 +245,13 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 	for _, row := range rows {
 		pkValue := row[pkIndex]
 
-		switch config.OnConflict {
+		// Default to overwrite if not specified or invalid
+		onConflict := config.OnConflict
+		if onConflict != "overwrite" && onConflict != "skip" {
+			onConflict = "overwrite"
+		}
+
+		switch onConflict {
 		case "overwrite":
 			// "overwrite" strategy:
 			// - If record exists: UPDATE only columns in this sink (preserve other columns)

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -100,16 +100,19 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 		}
 	}
 
-	if pkIndex == -1 && config.OnConflict == "overwrite" {
+	// Normalize onConflict first, then validate based on normalized value
+	normalizedOnConflict := config.OnConflict
+	if normalizedOnConflict != "overwrite" && normalizedOnConflict != "skip" {
+		normalizedOnConflict = "overwrite"
+	}
+
+	// For overwrite strategy, PK must exist in columns
+	if pkIndex == -1 && normalizedOnConflict == "overwrite" {
 		return fmt.Errorf("primary key %s not found in columns", pkColumn)
 	}
 
 	for _, row := range rows {
-		// Default to overwrite if not specified or invalid
-		onConflict := config.OnConflict
-		if onConflict != "overwrite" && onConflict != "skip" {
-			onConflict = "overwrite"
-		}
+		onConflict := normalizedOnConflict
 
 		switch onConflict {
 		case "overwrite":
@@ -249,22 +252,24 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 		return fmt.Errorf("primary key %s not found", pkColumn)
 	}
 
+	// Normalize onConflict before use
+	normalizedOnConflict := config.OnConflict
+	if normalizedOnConflict != "overwrite" && normalizedOnConflict != "skip" {
+		normalizedOnConflict = "overwrite"
+	}
+
 	slog.Debug("sqliteutil.UpdateInTx: starting update",
 		"table", config.Output,
 		"primaryKey", pkColumn,
 		"pkIndex", pkIndex,
-		"onConflict", config.OnConflict,
+		"onConflict", normalizedOnConflict,
 		"columns", columns,
 		"rows", len(rows))
 
 	for _, row := range rows {
 		pkValue := row[pkIndex]
 
-		// Default to overwrite if not specified or invalid
-		onConflict := config.OnConflict
-		if onConflict != "overwrite" && onConflict != "skip" {
-			onConflict = "overwrite"
-		}
+		onConflict := normalizedOnConflict
 
 		switch onConflict {
 		case "overwrite":

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -118,7 +118,7 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 			// - If record doesn't exist: INSERT new record
 			pkValue := row[pkIndex]
 
-			// First, try UPDATE (only update columns in this sink, preserve other columns)
+			// Build SET clause (exclude PK column from update)
 			var setClauses []string
 			var updateValues []any
 			for colIdx, col := range columns {
@@ -128,51 +128,66 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
 				updateValues = append(updateValues, row[colIdx])
 			}
-			updateValues = append(updateValues, pkValue)
 
-			updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
-				config.Output,
-				strings.Join(setClauses, ", "),
-				pkColumn)
+			// check if we can perform UPDATE (need non-PK columns)
+			canUpdate := len(setClauses) > 0
 
-			slog.Debug("sqliteutil.InsertInTx: executing update",
-				"table", config.Output,
-				"sql", updateSQL,
-				"pkValue", pkValue)
-			result, err := tx.Exec(updateSQL, updateValues...)
-			if err != nil {
-				slog.Error("sqliteutil.InsertInTx: update failed",
+			if canUpdate {
+				updateValues = append(updateValues, pkValue)
+
+				updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
+					config.Output,
+					strings.Join(setClauses, ", "),
+					pkColumn)
+
+				slog.Debug("sqliteutil.InsertInTx: executing update",
 					"table", config.Output,
 					"sql", updateSQL,
-					"err", err)
-				return fmt.Errorf("update: %w", err)
+					"pkValue", pkValue)
+				// Normalize values for UPDATE
+				normalizedUpdateValues := normalizeRowValues(columns, updateValues)
+				result, err := tx.Exec(updateSQL, normalizedUpdateValues...)
+				if err != nil {
+					slog.Error("sqliteutil.InsertInTx: update failed",
+						"table", config.Output,
+						"sql", updateSQL,
+						"err", err)
+					return fmt.Errorf("update: %w", err)
+				}
+
+				rowsAffected, _ := result.RowsAffected()
+				if rowsAffected > 0 {
+					// Successfully updated existing row
+					slog.Debug("sqliteutil.InsertInTx: updated existing row",
+						"table", config.Output,
+						"pkValue", pkValue)
+					continue
+				}
 			}
 
-			rowsAffected, _ := result.RowsAffected()
-			if rowsAffected == 0 {
-				// No row exists, INSERT new record
-				var placeholders []string
-				for range columns {
-					placeholders = append(placeholders, "?")
-				}
-				insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-					config.Output,
-					strings.Join(escapedColumns(columns), ", "),
-					strings.Join(placeholders, ", "))
+			// No row exists (or can't update), INSERT new record
+			var placeholders []string
+			for range columns {
+				placeholders = append(placeholders, "?")
+			}
+			insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+				config.Output,
+				strings.Join(escapedColumns(columns), ", "),
+				strings.Join(placeholders, ", "))
 
-				slog.Debug("sqliteutil.InsertInTx: executing insert",
+			slog.Debug("sqliteutil.InsertInTx: executing insert",
+				"table", config.Output,
+				"sql", insertSQL,
+				"pkValue", pkValue)
+			// Normalize values for INSERT
+			normalizedRow := normalizeRowValues(columns, row)
+			_, err := tx.Exec(insertSQL, normalizedRow...)
+			if err != nil {
+				slog.Error("sqliteutil.InsertInTx: insert failed",
 					"table", config.Output,
 					"sql", insertSQL,
-					"pkValue", pkValue)
-				normalizedRow := normalizeRowValues(columns, row)
-				_, err := tx.Exec(insertSQL, normalizedRow...)
-				if err != nil {
-					slog.Error("sqliteutil.InsertInTx: insert failed",
-						"table", config.Output,
-						"sql", insertSQL,
-						"err", err)
-					return fmt.Errorf("insert: %w", err)
-				}
+					"err", err)
+				return fmt.Errorf("insert: %w", err)
 			}
 		default:
 			// Default strategy: INSERT OR REPLACE
@@ -258,7 +273,7 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 			// - If record doesn't exist: INSERT the record
 			// This achieves partial update without overwriting entire row
 
-			// First, try UPDATE (only update columns in this sink, preserve other columns)
+			// Build SET clause (exclude PK column from update)
 			var setClauses []string
 			var updateValues []any
 			for colIdx, col := range columns {
@@ -268,50 +283,66 @@ func UpdateInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
 				updateValues = append(updateValues, row[colIdx])
 			}
-			updateValues = append(updateValues, pkValue)
 
-			updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
-				config.Output,
-				strings.Join(setClauses, ", "),
-				pkColumn)
+			// Check if we can perform UPDATE (need non-PK columns)
+			canUpdate := len(setClauses) > 0
 
-			slog.Debug("sqliteutil.UpdateInTx: executing update",
-				"table", config.Output,
-				"sql", updateSQL,
-				"pkValue", pkValue)
-			result, err := tx.Exec(updateSQL, updateValues...)
-			if err != nil {
-				slog.Error("sqliteutil.UpdateInTx: update failed",
+			if canUpdate {
+				updateValues = append(updateValues, pkValue)
+
+				updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
+					config.Output,
+					strings.Join(setClauses, ", "),
+					pkColumn)
+
+				slog.Debug("sqliteutil.UpdateInTx: executing update",
 					"table", config.Output,
 					"sql", updateSQL,
-					"err", err)
-				return fmt.Errorf("update: %w", err)
+					"pkValue", pkValue)
+				// Normalize values for UPDATE
+				normalizedUpdateValues := normalizeRowValues(columns, updateValues)
+				result, err := tx.Exec(updateSQL, normalizedUpdateValues...)
+				if err != nil {
+					slog.Error("sqliteutil.UpdateInTx: update failed",
+						"table", config.Output,
+						"sql", updateSQL,
+						"err", err)
+					return fmt.Errorf("update: %w", err)
+				}
+
+				rowsAffected, _ := result.RowsAffected()
+				if rowsAffected > 0 {
+					// Successfully updated existing row
+					slog.Debug("sqliteutil.UpdateInTx: updated existing row",
+						"table", config.Output,
+						"pkValue", pkValue)
+					continue
+				}
 			}
 
-			rowsAffected, _ := result.RowsAffected()
-			if rowsAffected == 0 {
-				// No row exists, INSERT new record
-				var placeholders []string
-				for range columns {
-					placeholders = append(placeholders, "?")
-				}
-				insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-					config.Output,
-					strings.Join(escapedColumns(columns), ", "),
-					strings.Join(placeholders, ", "))
+			// No row exists (or can't update), INSERT new record
+			var placeholders []string
+			for range columns {
+				placeholders = append(placeholders, "?")
+			}
+			insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+				config.Output,
+				strings.Join(escapedColumns(columns), ", "),
+				strings.Join(placeholders, ", "))
 
-				slog.Debug("sqliteutil.UpdateInTx: executing insert",
+			slog.Debug("sqliteutil.UpdateInTx: executing insert",
+				"table", config.Output,
+				"sql", insertSQL,
+				"pkValue", pkValue)
+			// Normalize values for INSERT
+			normalizedRow := normalizeRowValues(columns, row)
+			_, err := tx.Exec(insertSQL, normalizedRow...)
+			if err != nil {
+				slog.Error("sqliteutil.UpdateInTx: insert failed",
 					"table", config.Output,
 					"sql", insertSQL,
-					"pkValue", pkValue)
-				_, err := tx.Exec(insertSQL, row...)
-				if err != nil {
-					slog.Error("sqliteutil.UpdateInTx: insert failed",
-						"table", config.Output,
-						"sql", insertSQL,
-						"err", err)
-					return fmt.Errorf("insert: %w", err)
-				}
+					"err", err)
+				return fmt.Errorf("insert: %w", err)
 			}
 		case "skip", "":
 			// Use INSERT OR IGNORE: does nothing if row with PK already exists

--- a/internal/sqliteutil/util.go
+++ b/internal/sqliteutil/util.go
@@ -71,9 +71,12 @@ func normalizeRowValues(columns []string, row []interface{}) []interface{} {
 	return result
 }
 
-// InsertInTx inserts DataSet into table using INSERT OR REPLACE strategy.
-// Tables must be created via migrations before calling this function.
-// This function will NOT create tables - it assumes the table already exists.
+// InsertInTx inserts DataSet into table.
+// For "overwrite" strategy:
+//   - If record exists: UPDATE only columns provided (preserve other columns)
+//   - If record doesn't exist: INSERT new record
+// For "skip"/"": INSERT OR IGNORE (do nothing if exists)
+// For other cases: standard INSERT
 func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interface{}) error {
 	if len(rows) == 0 {
 		return nil
@@ -82,33 +85,115 @@ func InsertInTx(tx TxExec, config TableConfig, columns []string, rows [][]interf
 	slog.Debug("sqliteutil.InsertInTx: starting insert",
 		"table", config.Output,
 		"primaryKey", config.PrimaryKey,
+		"onConflict", config.OnConflict,
 		"columns", columns,
 		"rows", len(rows))
 
-	for _, row := range rows {
-		sqlStr := BuildInsertSQL(config.Output, columns, true)
-		slog.Debug("sqliteutil.InsertInTx: executing",
-			"table", config.Output,
-			"sql", sqlStr,
-			"rowLen", len(row))
+	pkColumn := config.PrimaryKey
 
-		// Pass row directly - driver handles time.Time serialization
-		normalizedRow := normalizeRowValues(columns, row)
-		fmt.Printf("DEBUG Exec: table=%s, sql=%s, normalizedRow len=%d\n", config.Output, sqlStr, len(normalizedRow))
-		result, err := tx.Exec(sqlStr, normalizedRow...)
-		if err != nil {
-			slog.Error("sqliteutil.InsertInTx: exec failed",
+	// Find PK index
+	pkIndex := -1
+	for i, col := range columns {
+		if col == pkColumn {
+			pkIndex = i
+			break
+		}
+	}
+
+	if pkIndex == -1 && config.OnConflict == "overwrite" {
+		return fmt.Errorf("primary key %s not found in columns", pkColumn)
+	}
+
+	for _, row := range rows {
+		switch config.OnConflict {
+		case "overwrite":
+			// "overwrite" strategy: partial update
+			// - If record exists: UPDATE only provided columns (preserve other columns)
+			// - If record doesn't exist: INSERT new record
+			pkValue := row[pkIndex]
+
+			// First, try UPDATE (only update columns in this sink, preserve other columns)
+			var setClauses []string
+			var updateValues []any
+			for colIdx, col := range columns {
+				if col == pkColumn {
+					continue // Skip PK in SET clause
+				}
+				setClauses = append(setClauses, fmt.Sprintf("[%s] = ?", col))
+				updateValues = append(updateValues, row[colIdx])
+			}
+			updateValues = append(updateValues, pkValue)
+
+			updateSQL := fmt.Sprintf("UPDATE %s SET %s WHERE [%s] = ?",
+				config.Output,
+				strings.Join(setClauses, ", "),
+				pkColumn)
+
+			slog.Debug("sqliteutil.InsertInTx: executing update",
+				"table", config.Output,
+				"sql", updateSQL,
+				"pkValue", pkValue)
+			result, err := tx.Exec(updateSQL, updateValues...)
+			if err != nil {
+				slog.Error("sqliteutil.InsertInTx: update failed",
+					"table", config.Output,
+					"sql", updateSQL,
+					"err", err)
+				return fmt.Errorf("update: %w", err)
+			}
+
+			rowsAffected, _ := result.RowsAffected()
+			if rowsAffected == 0 {
+				// No row exists, INSERT new record
+				var placeholders []string
+				for range columns {
+					placeholders = append(placeholders, "?")
+				}
+				insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+					config.Output,
+					strings.Join(escapedColumns(columns), ", "),
+					strings.Join(placeholders, ", "))
+
+				slog.Debug("sqliteutil.InsertInTx: executing insert",
+					"table", config.Output,
+					"sql", insertSQL,
+					"pkValue", pkValue)
+				normalizedRow := normalizeRowValues(columns, row)
+				_, err := tx.Exec(insertSQL, normalizedRow...)
+				if err != nil {
+					slog.Error("sqliteutil.InsertInTx: insert failed",
+						"table", config.Output,
+						"sql", insertSQL,
+						"err", err)
+					return fmt.Errorf("insert: %w", err)
+				}
+			}
+		default:
+			// Default strategy: INSERT OR REPLACE
+			sqlStr := BuildInsertSQL(config.Output, columns, true)
+			slog.Debug("sqliteutil.InsertInTx: executing",
 				"table", config.Output,
 				"sql", sqlStr,
-				"err", err)
-			return fmt.Errorf("execute: %w", err)
-		}
+				"rowLen", len(row))
 
-		if result != nil {
-			rowsAffected, _ := result.RowsAffected()
-			slog.Debug("sqliteutil.InsertInTx: rows affected",
-				"table", config.Output,
-				"rowsAffected", rowsAffected)
+			// Pass row directly - driver handles time.Time serialization
+			normalizedRow := normalizeRowValues(columns, row)
+			fmt.Printf("DEBUG Exec: table=%s, sql=%s, normalizedRow len=%d\n", config.Output, sqlStr, len(normalizedRow))
+			result, err := tx.Exec(sqlStr, normalizedRow...)
+			if err != nil {
+				slog.Error("sqliteutil.InsertInTx: exec failed",
+					"table", config.Output,
+					"sql", sqlStr,
+					"err", err)
+				return fmt.Errorf("execute: %w", err)
+			}
+
+			if result != nil {
+				rowsAffected, _ := result.RowsAffected()
+				slog.Debug("sqliteutil.InsertInTx: rows affected",
+					"table", config.Output,
+					"rowsAffected", rowsAffected)
+			}
 		}
 
 		slog.Debug("sqliteutil.InsertInTx: statement buffered",


### PR DESCRIPTION
## Summary
- Change `on_conflict: overwrite` strategy to use UPDATE instead of INSERT OR REPLACE
- When record exists: UPDATE only the columns provided by the current sink (preserves other columns)
- When record doesn't exist: INSERT new record with provided columns
- Fixes issue where costitemexd sink was deleting entire row when updating

## Test plan
- [ ] Deploy to test environment
- [ ] Trigger CostitemExd insert/update
- [ ] Verify Costitem table retains other columns after sink execution

## Summary by Sourcery

Change SQLite overwrite strategy to perform partial updates instead of full row replacement while preserving existing columns.

Bug Fixes:
- Prevent overwrite strategy from deleting or replacing entire rows when only a subset of columns is provided.

Enhancements:
- Add conditional UPDATE-then-INSERT behavior for overwrite strategy to update existing rows or insert new ones as needed.
- Improve logging and configuration handling in UpdateInTx to include conflict strategy and primary key metadata.