### PR TITLE
refactor: extract snapshot to independent package

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-package cdc
+package snapshot
 
 import (
 	"context"
@@ -9,38 +9,40 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cnlangzi/dbkrab/internal/cdc"
+	"github.com/cnlangzi/dbkrab/internal/core"
 	scannerpkg "github.com/cnlangzi/dbkrab/internal/scanner"
 )
 
-// SnapshotConfig holds configuration for snapshot sync
-type SnapshotConfig struct {
+// Config holds configuration for snapshot sync
+type Config struct {
 	BatchSize int `yaml:"batch_size"`
 }
 
-// DefaultSnapshotConfig returns default snapshot configuration
-func DefaultSnapshotConfig() *SnapshotConfig {
-	return &SnapshotConfig{
+// DefaultConfig returns default snapshot configuration
+func DefaultConfig() *Config {
+	return &Config{
 		BatchSize: 10000,
 	}
 }
 
-// SnapshotQuerier performs full-table snapshot sync (initial sync without CDC)
-type SnapshotQuerier struct {
+// Querier performs full-table snapshot sync (initial sync without CDC)
+type Querier struct {
 	db       *sql.DB
 	timezone *time.Location
-	factory  *ScannerFactory
-	config   *SnapshotConfig
+	factory  *cdc.ScannerFactory
+	config   *Config
 }
 
-// NewSnapshotQuerier creates a new SnapshotQuerier
-func NewSnapshotQuerier(db *sql.DB, timezone *time.Location, config *SnapshotConfig) *SnapshotQuerier {
+// NewQuerier creates a new snapshot Querier
+func NewQuerier(db *sql.DB, timezone *time.Location, config *Config) *Querier {
 	if config == nil {
-		config = DefaultSnapshotConfig()
+		config = DefaultConfig()
 	}
-	return &SnapshotQuerier{
+	return &Querier{
 		db:       db,
 		timezone: timezone,
-		factory:  NewScannerFactory(timezone),
+		factory:  cdc.NewScannerFactory(timezone),
 		config:   config,
 	}
 }
@@ -52,7 +54,7 @@ type PrimaryKeyInfo struct {
 
 // DiscoverPrimaryKey discovers primary key columns for a table
 // Uses sys.index_columns / sys.indexes / sys.columns ordered by key_ordinal
-func (q *SnapshotQuerier) DiscoverPrimaryKey(ctx context.Context, schema, table string) (*PrimaryKeyInfo, error) {
+func (q *Querier) DiscoverPrimaryKey(ctx context.Context, schema, table string) (*PrimaryKeyInfo, error) {
 	query := `
 		SELECT c.name AS column_name
 		FROM sys.index_columns ic
@@ -109,7 +111,7 @@ func (pki *PrimaryKeyInfo) BuildPagedQuery(schema, table string, batchSize int, 
 
 // GetMaxLSN returns the current max LSN (outside read transaction)
 // This is used to capture a stable LSN checkpoint before snapshot
-func (q *SnapshotQuerier) GetMaxLSN(ctx context.Context) ([]byte, error) {
+func (q *Querier) GetMaxLSN(ctx context.Context) ([]byte, error) {
 	var lsn []byte
 	err := q.db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_max_lsn()").Scan(&lsn)
 	return lsn, err
@@ -117,7 +119,7 @@ func (q *SnapshotQuerier) GetMaxLSN(ctx context.Context) ([]byte, error) {
 
 // CheckSnapshotIsolation checks if ALLOW_SNAPSHOT_ISOLATION is enabled on the database
 // and attempts to enable it if not. Returns error if not supported.
-func (q *SnapshotQuerier) CheckSnapshotIsolation(ctx context.Context) error {
+func (q *Querier) CheckSnapshotIsolation(ctx context.Context) error {
 	// Check current snapshot isolation state
 	var isAllowed int
 	err := q.db.QueryRowContext(ctx, `
@@ -148,24 +150,24 @@ func (q *SnapshotQuerier) CheckSnapshotIsolation(ctx context.Context) error {
 }
 
 // IncrementLSN returns the next LSN after the given one
-func (q *SnapshotQuerier) IncrementLSN(ctx context.Context, lsn []byte) ([]byte, error) {
+func (q *Querier) IncrementLSN(ctx context.Context, lsn []byte) ([]byte, error) {
 	var nextLSN []byte
 	err := q.db.QueryRowContext(ctx, "SELECT sys.fn_cdc_increment_lsn(@p1)", lsn).Scan(&nextLSN)
 	return nextLSN, err
 }
 
-// SnapshotBatch represents a batch of rows from snapshot
-type SnapshotBatch struct {
+// Batch represents a batch of rows from snapshot
+type Batch struct {
 	Table   string
 	Offset  int
 	Rows    []map[string]interface{}
 	HasMore bool
 }
 
-// RunSnapshot runs a full-table snapshot for the given table
+// Run runs a full-table snapshot for the given table
 // It reads the table in batches and processes each batch through the handler
 // Returns the startLSN checkpoint that should be stored for subsequent CDC sync
-func (q *SnapshotQuerier) RunSnapshot(ctx context.Context, schema, table string, handler SnapshotHandler) ([]byte, error) {
+func (q *Querier) Run(ctx context.Context, schema, table string, handler Handler) ([]byte, error) {
 	// Step 0: Check and enable snapshot isolation on the database (must be done before starting transaction)
 	if err := q.CheckSnapshotIsolation(ctx); err != nil {
 		return nil, fmt.Errorf("snapshot isolation check: %w", err)
@@ -265,13 +267,13 @@ func (q *SnapshotQuerier) RunSnapshot(ctx context.Context, schema, table string,
 
 		// Process batch if we have rows
 		if len(batchRows) > 0 {
-			// Convert to cdc.Change format for skill pipeline
+			// Convert to core.Change format for skill pipeline
 			// Snapshot rows are treated as INSERT operations
-			changes := make([]Change, len(batchRows))
+			changes := make([]core.Change, len(batchRows))
 			for i, row := range batchRows {
-				changes[i] = Change{
+				changes[i] = core.Change{
 					Table:     table,
-					Operation: 2, // OpInsert = 2
+					Operation: core.OpInsert, // OpInsert = 2
 					Data:      row,
 					// LSN is set to empty bytes for snapshot rows (they don't come from CDC)
 					// The checkpoint is stored after snapshot completes
@@ -280,7 +282,7 @@ func (q *SnapshotQuerier) RunSnapshot(ctx context.Context, schema, table string,
 			}
 
 			// Process batch through handler (skill pipeline + sink)
-			if err := handler.HandleSnapshotBatch(ctx, changes); err != nil {
+			if err := handler.HandleBatch(ctx, changes); err != nil {
 				return nil, fmt.Errorf("handle batch at offset %d: %w", offset, err)
 			}
 
@@ -317,17 +319,16 @@ func (q *SnapshotQuerier) RunSnapshot(ctx context.Context, schema, table string,
 	return startLSN, nil
 }
 
-// SnapshotHandler processes snapshot batches through skill pipeline and sink
-// Uses cdc.Change type to avoid import cycle with core package
-type SnapshotHandler interface {
-	HandleSnapshotBatch(ctx context.Context, changes []Change) error
+// Handler processes snapshot batches through skill pipeline and sink
+type Handler interface {
+	HandleBatch(ctx context.Context, changes []core.Change) error
 }
 
-// SnapshotHandlerFunc is a function type adapter for SnapshotHandler
-type SnapshotHandlerFunc func(ctx context.Context, changes []Change) error
+// HandlerFunc is a function type adapter for Handler
+type HandlerFunc func(ctx context.Context, changes []core.Change) error
 
-// HandleSnapshotBatch implements SnapshotHandler interface
-func (f SnapshotHandlerFunc) HandleSnapshotBatch(ctx context.Context, changes []Change) error {
+// HandleBatch implements Handler interface
+func (f HandlerFunc) HandleBatch(ctx context.Context, changes []core.Change) error {
 	return f(ctx, changes)
 }
 
@@ -337,27 +338,27 @@ type OffsetUpdater interface {
 	Flush() error
 }
 
-// SnapshotRunner coordinates full snapshot run with offset update
-type SnapshotRunner struct {
-	querier     *SnapshotQuerier
+// Runner coordinates full snapshot run with offset update
+type Runner struct {
+	querier     *Querier
 	offsetStore OffsetUpdater
 }
 
-// NewSnapshotRunner creates a new snapshot runner
-func NewSnapshotRunner(querier *SnapshotQuerier, offsetStore OffsetUpdater) *SnapshotRunner {
-	return &SnapshotRunner{
+// NewRunner creates a new snapshot Runner
+func NewRunner(querier *Querier, offsetStore OffsetUpdater) *Runner {
+	return &Runner{
 		querier:     querier,
 		offsetStore: offsetStore,
 	}
 }
 
-// RunFullSnapshot runs snapshot for a table and updates offset store on success
+// RunFull runs snapshot for a table and updates offset store on success
 // schema should be like "dbo", table is the table name without schema
-func (r *SnapshotRunner) RunFullSnapshot(ctx context.Context, schema, table string, handler SnapshotHandler) error {
+func (r *Runner) RunFull(ctx context.Context, schema, table string, handler Handler) error {
 	fullTableName := schema + "." + table
 
 	// Run snapshot and get start LSN checkpoint
-	startLSN, err := r.querier.RunSnapshot(ctx, schema, table, handler)
+	startLSN, err := r.querier.Run(ctx, schema, table, handler)
 	if err != nil {
 		return fmt.Errorf("snapshot run: %w", err)
 	}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -14,19 +14,23 @@ import (
 	scannerpkg "github.com/cnlangzi/dbkrab/internal/scanner"
 )
 
-// Config holds configuration for snapshot sync
+// Config holds configuration for snapshot sync operations.
+// BatchSize determines how many rows are fetched per batch during snapshot.
 type Config struct {
+	// BatchSize is the number of rows to fetch per batch (default: 10000).
 	BatchSize int `yaml:"batch_size"`
 }
 
-// DefaultConfig returns default snapshot configuration
+// DefaultConfig returns the default snapshot configuration with BatchSize=10000.
 func DefaultConfig() *Config {
 	return &Config{
 		BatchSize: 10000,
 	}
 }
 
-// Querier performs full-table snapshot sync (initial sync without CDC)
+// Querier performs full-table snapshot sync (initial sync without CDC).
+// It reads all rows from a table using snapshot isolation and converts them
+// to core.Change records for downstream processing.
 type Querier struct {
 	db       *sql.DB
 	timezone *time.Location
@@ -34,7 +38,9 @@ type Querier struct {
 	config   *Config
 }
 
-// NewQuerier creates a new snapshot Querier
+// NewQuerier creates a new snapshot Querier with the given database connection,
+// timezone for timestamp conversion, and optional configuration.
+// If config is nil, DefaultConfig() is used.
 func NewQuerier(db *sql.DB, timezone *time.Location, config *Config) *Querier {
 	if config == nil {
 		config = DefaultConfig()
@@ -47,7 +53,8 @@ func NewQuerier(db *sql.DB, timezone *time.Location, config *Config) *Querier {
 	}
 }
 
-// PrimaryKeyInfo holds primary key column information for a table
+// PrimaryKeyInfo holds primary key column information for pagination queries.
+// Columns are ordered by key_ordinal from sys.index_columns.
 type PrimaryKeyInfo struct {
 	Columns []string // Column names in key ordinal order
 }
@@ -93,7 +100,7 @@ func (q *Querier) DiscoverPrimaryKey(ctx context.Context, schema, table string) 
 	return &PrimaryKeyInfo{Columns: pkColumns}, nil
 }
 
-// BuildOrderBy builds ORDER BY clause from PK columns
+// BuildOrderBy builds ORDER BY clause from PK columns for pagination queries.
 func (pki *PrimaryKeyInfo) BuildOrderBy() string {
 	return strings.Join(pki.Columns, ", ")
 }
@@ -156,7 +163,8 @@ func (q *Querier) IncrementLSN(ctx context.Context, lsn []byte) ([]byte, error) 
 	return nextLSN, err
 }
 
-// Batch represents a batch of rows from snapshot
+// Batch represents a batch of rows fetched during snapshot pagination.
+// HasMore indicates whether more rows exist beyond the current batch.
 type Batch struct {
 	Table   string
 	Offset  int
@@ -319,32 +327,36 @@ func (q *Querier) Run(ctx context.Context, schema, table string, handler Handler
 	return startLSN, nil
 }
 
-// Handler processes snapshot batches through skill pipeline and sink
+// Handler processes snapshot batches through skill pipeline and sink.
+// Implementations should handle each batch of core.Change records.
 type Handler interface {
 	HandleBatch(ctx context.Context, changes []core.Change) error
 }
 
-// HandlerFunc is a function type adapter for Handler
+// HandlerFunc is a function type adapter that allows using ordinary
+// functions as Handler implementations.
 type HandlerFunc func(ctx context.Context, changes []core.Change) error
 
-// HandleBatch implements Handler interface
+// HandleBatch implements the Handler interface by calling the function itself.
 func (f HandlerFunc) HandleBatch(ctx context.Context, changes []core.Change) error {
 	return f(ctx, changes)
 }
 
-// OffsetUpdater updates offset storage after snapshot completes
+// OffsetUpdater updates offset storage after snapshot completes.
+// It persists the LSN checkpoint so subsequent CDC sync can resume correctly.
 type OffsetUpdater interface {
 	Set(table string, lastLSN string, nextLSN string) error
 	Flush() error
 }
 
-// Runner coordinates full snapshot run with offset update
+// Runner coordinates full snapshot run with offset update.
+// It runs the snapshot querier and persists the resulting LSN checkpoint.
 type Runner struct {
 	querier     *Querier
 	offsetStore OffsetUpdater
 }
 
-// NewRunner creates a new snapshot Runner
+// NewRunner creates a new snapshot Runner with the given querier and offset store.
 func NewRunner(querier *Querier, offsetStore OffsetUpdater) *Runner {
 	return &Runner{
 		querier:     querier,
@@ -352,8 +364,9 @@ func NewRunner(querier *Querier, offsetStore OffsetUpdater) *Runner {
 	}
 }
 
-// RunFull runs snapshot for a table and updates offset store on success
-// schema should be like "dbo", table is the table name without schema
+// RunFull runs snapshot for a table and updates offset store on success.
+// The schema parameter should be like "dbo", and table is the table name without schema.
+// After snapshot completes, the LSN checkpoint is stored so CDC can resume.
 func (r *Runner) RunFull(ctx context.Context, schema, table string, handler Handler) error {
 	fullTableName := schema + "." + table
 

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cnlangzi/dbkrab/internal/core"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrimaryKeyInfo_BuildOrderBy(t *testing.T) {
@@ -185,7 +186,8 @@ func TestNewQuerier_WithDefaults(t *testing.T) {
 }
 
 func TestNewQuerier_Timezone(t *testing.T) {
-	loc, _ := time.LoadLocation("Asia/Shanghai")
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err, "Failed to load timezone")
 	q := NewQuerier(nil, loc, nil)
 
 	if q.timezone != loc {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -1,10 +1,12 @@
-package cdc
+package snapshot
 
 import (
 	"context"
 	"encoding/hex"
 	"testing"
 	"time"
+
+	"github.com/cnlangzi/dbkrab/internal/core"
 )
 
 func TestPrimaryKeyInfo_BuildOrderBy(t *testing.T) {
@@ -90,21 +92,21 @@ func TestPrimaryKeyInfo_BuildPagedQuery(t *testing.T) {
 	}
 }
 
-func TestSnapshotConfig_Defaults(t *testing.T) {
-	cfg := DefaultSnapshotConfig()
+func TestConfig_Defaults(t *testing.T) {
+	cfg := DefaultConfig()
 	if cfg.BatchSize != 10000 {
-		t.Errorf("DefaultSnapshotConfig().BatchSize = %d, want 10000", cfg.BatchSize)
+		t.Errorf("DefaultConfig().BatchSize = %d, want 10000", cfg.BatchSize)
 	}
 }
 
-func TestSnapshotConfig_CustomBatchSize(t *testing.T) {
-	cfg := &SnapshotConfig{BatchSize: 5000}
+func TestConfig_CustomBatchSize(t *testing.T) {
+	cfg := &Config{BatchSize: 5000}
 	if cfg.BatchSize != 5000 {
-		t.Errorf("SnapshotConfig.BatchSize = %d, want 5000", cfg.BatchSize)
+		t.Errorf("Config.BatchSize = %d, want 5000", cfg.BatchSize)
 	}
 }
 
-func TestSnapshotQuerier_LSNCapture(t *testing.T) {
+func TestQuerier_LSNCapture(t *testing.T) {
 	startLSN := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
 
 	// Test hex encoding - should be 20 hex chars for 10 bytes
@@ -115,7 +117,7 @@ func TestSnapshotQuerier_LSNCapture(t *testing.T) {
 	}
 }
 
-func TestSnapshotQuerier_IncrementLSN(t *testing.T) {
+func TestQuerier_IncrementLSN(t *testing.T) {
 	startLSN := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
 
 	if len(startLSN) != 10 {
@@ -131,13 +133,13 @@ func TestSnapshotQuerier_IncrementLSN(t *testing.T) {
 	}
 }
 
-// testSnapshotHandler collects changes for testing
-type testSnapshotHandler struct {
-	changes [][]Change
+// testHandler collects changes for testing
+type testHandler struct {
+	changes [][]core.Change
 	err     error
 }
 
-func (h *testSnapshotHandler) HandleSnapshotBatch(ctx context.Context, changes []Change) error {
+func (h *testHandler) HandleBatch(ctx context.Context, changes []core.Change) error {
 	if h.err != nil {
 		return h.err
 	}
@@ -174,41 +176,41 @@ func (s *testOffsetStore) Get(table string) (string, string, bool) {
 	return "", "", false
 }
 
-func TestNewSnapshotQuerier_WithDefaults(t *testing.T) {
-	config := DefaultSnapshotConfig()
+func TestNewQuerier_WithDefaults(t *testing.T) {
+	config := DefaultConfig()
 
 	if config.BatchSize != 10000 {
 		t.Errorf("Default BatchSize = %d, want 10000", config.BatchSize)
 	}
 }
 
-func TestNewSnapshotQuerier_Timezone(t *testing.T) {
+func TestNewQuerier_Timezone(t *testing.T) {
 	loc, _ := time.LoadLocation("Asia/Shanghai")
-	q := NewSnapshotQuerier(nil, loc, nil)
+	q := NewQuerier(nil, loc, nil)
 
 	if q.timezone != loc {
 		t.Errorf("timezone = %v, want %v", q.timezone, loc)
 	}
 }
 
-func TestSnapshotHandlerFunc(t *testing.T) {
+func TestHandlerFunc(t *testing.T) {
 	var called bool
-	var captured []Change
+	var captured []core.Change
 
-	handler := SnapshotHandlerFunc(func(ctx context.Context, changes []Change) error {
+	handler := HandlerFunc(func(ctx context.Context, changes []core.Change) error {
 		called = true
 		captured = changes
 		return nil
 	})
 
 	ctx := context.Background()
-	testChanges := []Change{
-		{Table: "test", Operation: 2, Data: map[string]interface{}{"id": 1}},
+	testChanges := []core.Change{
+		{Table: "test", Operation: core.OpInsert, Data: map[string]interface{}{"id": 1}},
 	}
 
-	err := handler.HandleSnapshotBatch(ctx, testChanges)
+	err := handler.HandleBatch(ctx, testChanges)
 	if err != nil {
-		t.Errorf("HandleSnapshotBatch error = %v", err)
+		t.Errorf("HandleBatch error = %v", err)
 	}
 	if !called {
 		t.Error("handler was not called")
@@ -218,7 +220,7 @@ func TestSnapshotHandlerFunc(t *testing.T) {
 	}
 }
 
-func TestSnapshotRunner_OffsetUpdate(t *testing.T) {
+func TestRunner_OffsetUpdate(t *testing.T) {
 	store := newTestOffsetStore()
 
 	err := store.Set("dbo.test_table", "000000000000000001", "000000000000000002")
@@ -246,7 +248,7 @@ func TestSnapshotRunner_OffsetUpdate(t *testing.T) {
 	}
 }
 
-func TestSnapshotRunner_GetNonExistentOffset(t *testing.T) {
+func TestRunner_GetNonExistentOffset(t *testing.T) {
 	store := newTestOffsetStore()
 
 	_, _, ok := store.Get("dbo.non_existent")

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -166,7 +166,7 @@ func TestIntegrationWithSQLite(t *testing.T) {
 	mockDB := setupMockDB(t)
 	defer func() { _ = mockDB.Close() }()
 
-	// Setup real SQLite store
+	// Setup real SQLite store (migrations are run automatically by store.New)
 	sqliteDB, cleanupSQLite := setupSQLiteTestDB(t)
 	defer cleanupSQLite()
 
@@ -212,12 +212,9 @@ func TestIntegrationWithSQLite(t *testing.T) {
 			}
 		}
 
-		// Try to write to SQLite store (this may fail due to schema, but that's expected)
+		// Write to SQLite store (schema should exist after Migrate)
 		_, err = storeWrapper.Write(coreChanges)
-		if err != nil {
-			// Schema might not exist - this is OK for integration test
-			t.Logf("Expected schema error: %v", err)
-		}
+		require.NoError(t, err, "Failed to write changes to SQLite store")
 
 		// Test offset store
 		err = offsetStore.Set("dbo.TestProducts", "000000000100000001", "000000000100000002")
@@ -307,7 +304,7 @@ func TestCDCChangeTypes(t *testing.T) {
 
 // TestSQLiteStoreWrites verifies that real SQLite store can write data
 func TestSQLiteStoreWrites(t *testing.T) {
-	// Setup real SQLite store
+	// Setup real SQLite store (migrations are run automatically by store.New)
 	sqliteDB, cleanupSQLite := setupSQLiteTestDB(t)
 	defer cleanupSQLite()
 
@@ -332,13 +329,9 @@ func TestSQLiteStoreWrites(t *testing.T) {
 		},
 	}
 
-	// Write to store
+	// Write to store (schema should exist after Migrate)
 	count, err := storeWrapper.Write(changes)
-	if err != nil {
-		// Schema might not exist - create it
-		t.Logf("Store write error (may need schema): %v", err)
-	} else {
-		assert.Equal(t, 1, count, "Should write 1 change")
-		t.Logf("Successfully wrote %d changes to SQLite", count)
-	}
+	require.NoError(t, err, "Failed to write changes to SQLite store")
+	assert.Equal(t, 1, count, "Should write 1 change")
+	t.Logf("Successfully wrote %d changes to SQLite", count)
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -240,17 +240,18 @@ func TestMockMSQLWithRealPoller(t *testing.T) {
 	offsetStore, cleanupOffset := setupOffsetStore(t)
 	defer cleanupOffset()
 
-	// Create mock CDCQuerier and verify it implements the interface
-	handler := mockmssql.HandlerForTest()
-	mockQuerier := mockmssql.NewCDCQuerier(handler)
-
-	// Verify we can use it through the cdc.Querier interface
+	// Create real cdc.Querier to verify it can query the mock database
+	ctx := context.Background()
 	q := cdc.NewQuerier(mockDB, time.UTC)
-	_ = q
+
+	// Verify cdc.Querier can use the mock database for LSN queries
+	maxLSN, err := q.GetMaxLSN(ctx)
+	require.NoError(t, err, "Failed to get max LSN via cdc.Querier")
+	assert.NotNil(t, maxLSN, "Max LSN should not be nil")
+	t.Logf("Max LSN via cdc.Querier: %x", maxLSN)
 
 	// Test offset store basic operations
-	ctx := context.Background()
-	err := offsetStore.Set("dbo.TestProducts", "000000000100000001", "000000000100000002")
+	err = offsetStore.Set("dbo.TestProducts", "000000000100000001", "000000000100000002")
 	require.NoError(t, err, "Failed to set offset")
 	err = offsetStore.Flush()
 	require.NoError(t, err, "Failed to flush offset")
@@ -260,9 +261,6 @@ func TestMockMSQLWithRealPoller(t *testing.T) {
 	require.NoError(t, err, "Failed to get offset")
 	assert.Equal(t, "000000000100000001", off.LastLSN, "LastLSN should match")
 	assert.Equal(t, "000000000100000002", off.NextLSN, "NextLSN should match")
-
-	// Verify mockQuerier returns changes
-	_, _ = mockQuerier.GetChanges(ctx, "dbo_TestProducts", "TestProducts", []byte{0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, []byte{0, 0, 0, 0, 1, 0, 0, 0, 0, 2})
 
 	t.Log("Mock MSSQL is compatible with CDCQuerier interface")
 }
@@ -284,22 +282,21 @@ func TestCDCChangeTypes(t *testing.T) {
 	// Test INSERT operation
 	changes, err := querier.GetChanges(ctx, "dbo_TestProducts", "TestProducts", baseLSN, nextLSN)
 	require.NoError(t, err)
+	require.Greater(t, len(changes), 0, "Should have at least one change when LSNs differ")
 
-	if len(changes) > 0 {
-		change := changes[0]
+	change := changes[0]
 
-		// Verify operation types (2 = INSERT per MSSQL CDC)
-		assert.Equal(t, 2, change.Operation, "Operation should be INSERT (2)")
+	// Verify operation types (2 = INSERT per MSSQL CDC)
+	assert.Equal(t, 2, change.Operation, "Operation should be INSERT (2)")
 
-		// Verify data fields exist
-		assert.Contains(t, change.Data, "productid")
-		assert.Contains(t, change.Data, "productname")
-		assert.Contains(t, change.Data, "price")
-		assert.Contains(t, change.Data, "stock")
+	// Verify data fields exist
+	assert.Contains(t, change.Data, "productid")
+	assert.Contains(t, change.Data, "productname")
+	assert.Contains(t, change.Data, "price")
+	assert.Contains(t, change.Data, "stock")
 
-		t.Logf("CDC Change: op=%d, table=%s, data=%v",
-			change.Operation, change.Table, change.Data)
-	}
+	t.Logf("CDC Change: op=%d, table=%s, data=%v",
+		change.Operation, change.Table, change.Data)
 }
 
 // TestSQLiteStoreWrites verifies that real SQLite store can write data

--- a/tests/integration/mockmssql/driver.go
+++ b/tests/integration/mockmssql/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"io"
+	"strings"
 )
 
 // Driver implements database/sql/driver.Driver
@@ -264,7 +265,7 @@ func normalizeQuery(query string) string {
 		}
 		result += string(c)
 	}
-	return result
+	return strings.TrimSpace(result)
 }
 
 func init() {

--- a/tests/integration/mockmssql/driver.go
+++ b/tests/integration/mockmssql/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -115,7 +116,8 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	case "SELECT sys.fn_cdc_get_min_lsn('dbo_TestOrderItems')":
 		return &mockResult{rowsAffected: 1}, nil
 	default:
-		return &mockResult{rowsAffected: 0}, nil
+		// Fail on unsupported SQL to catch regressions
+		return nil, fmt.Errorf("mockmssql: unsupported Exec query: %s", query)
 	}
 }
 
@@ -159,13 +161,16 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 				values:  [][]interface{}{},
 			}, nil
 		}
+		// Check for primary key discovery query
+		if strings.Contains(query, "sys.index_columns") && strings.Contains(query, "is_primary_key = 1") {
+			return &rows{
+				columns: []string{"column_name"},
+				values:  [][]interface{}{{"ProductID"}},
+			}, nil
+		}
+		// Fail on unsupported SQL to catch regressions
+		return nil, fmt.Errorf("mockmssql: unsupported Query: %s", query)
 	}
-
-	// Default: return empty result
-	return &rows{
-		columns: []string{},
-		values:  [][]interface{}{},
-	}, nil
 }
 
 // tx implements driver.Tx


### PR DESCRIPTION
Move snapshot.go from internal/cdc to internal/snapshot

- Change from cdc.Change to core.Change for better type safety
- Rename types: SnapshotQuerier->Querier, SnapshotRunner->Runner, etc.
- Update tests to use core.Change

## Summary by Sourcery

Extract snapshot functionality into a dedicated internal/snapshot package and introduce mock MSSQL infrastructure for integration-style testing without a real SQL Server instance.

New Features:
- Add a mock MSSQL sql.Driver and CDCQuerier under tests/integration to simulate CDC queries and LSN progression.
- Introduce an internal/snapshot package encapsulating snapshot configuration, querying, and runner coordination using core.Change types.
- Add integration-style tests that exercise snapshot, CDC querying, SQLite-backed store, and offset storage using the mock MSSQL driver.

Enhancements:
- Refactor snapshot types and APIs (config, querier, handler, runner) to use generic names and core.Change for better type safety and package boundaries.
- Replace direct MSSQL-dependent integration tests with tests built on the mock MSSQL driver and real SQLite stores for more reliable and self-contained test runs.

Tests:
- Expand unit tests for the snapshot package to cover configuration defaults, handler adapters, and runner offset behavior using the new types.
- Add comprehensive tests validating mock MSSQL driver behavior, CDC querier operations, and end-to-end integration with SQLite store and offset persistence.