### PR TITLE
Enable integration tests in CI and pre-commit hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: make vet
 
       - name: Run tests
-        run: go test -v -race -skip "Integration" ./...
+        run: go test -v -race ./...
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ build:
 	$(GO) build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./$(CMD_DIR)
 	@echo "Built: $(BUILD_DIR)/$(BINARY_NAME)"
 
-## test: Run all tests (excluding integration tests)
+## test: Run all tests
 test:
 	@echo "Running tests..."
-	$(GO) test -v -race -v $(TEST_PARALLEL) -skip "Integration" ./...
+	$(GO) test -v -race $(TEST_PARALLEL) ./...
 
 ## test-short: Run short tests
 test-short:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,136 +1,61 @@
 # dbkrab 集成测试
 
+## 概述
+
+集成测试使用 **Mock MSSQL Driver**（`mockmssql`），无需 Docker 或真实的 MSSQL 容器。
+
+Mock driver 模拟了 CDC 查询接口（`fn_cdc_get_max_lsn`、`fn_cdc_get_min_lsn` 等），提供测试数据，与真实 SQLite 存储层配合验证完整数据流。
+
 ## 本地运行
 
 ### 前提条件
 
-**必须安装 Docker**
+**无需 Docker**，只需 Go 环境。
+
+### 快速运行
 
 ```bash
-# Ubuntu/Debian
-curl -fsSL https://get.docker.com | sudo sh
-sudo usermod -aG docker $USER
-# 重新登录或运行: newgrp docker
+# 运行所有测试（包括集成测试）
+make test
 
-# 验证
-docker --version
+# 仅运行集成测试
+go test -v -race ./tests/integration/...
 ```
 
-### 快速运行（推荐）
+### Mock Driver 实现
 
-```bash
-cd tests/integration
-./run-local.sh
-```
+| 文件 | 说明 |
+|------|------|
+| `mockmssql/driver.go` | Mock MSSQL driver，注册为 `mockmssql` |
+| `mockmssql/cdc_querier.go` | 实现 `CDCQuerier` 接口 |
 
-脚本会：
-1. 自动检查 Docker 是否安装
-2. 启动 MSSQL Server 2022 容器（Developer Edition）
-3. 等待 SQL Server 就绪
-4. 运行初始化脚本（启用 CDC）
-5. 执行集成测试
-6. 询问是否清理容器
-
-### 手动运行
-
-```bash
-# 1. 启动 MSSQL 容器
-docker run -d \
-  --name dbkrab-test-mssql \
-  -e ACCEPT_EULA=Y \
-  -e MSSQL_SA_PASSWORD=Test1234! \
-  -e MSSQL_PID=Developer \
-  -p 1433:1433 \
-  mcr.microsoft.com/mssql/server:2022-latest
-
-# 2. 等待启动（约 30 秒）
-docker logs -f dbkrab-test-mssql
-
-# 3. 运行初始化脚本
-docker exec -i dbkrab-test-mssql /opt/mssql-tools/bin/sqlcmd \
-  -S localhost -U sa -P 'Test1234!' \
-  < tests/integration/setup.sql
-
-# 4. 运行测试
-cd tests/integration
-MSSQL_HOST=localhost \
-MSSQL_PORT=1433 \
-MSSQL_USER=sa \
-MSSQL_PASSWORD=Test1234! \
-MSSQL_DATABASE=dbkrab_test \
-go test -v -race -timeout=5m ./...
-
-# 5. 清理容器
-docker stop dbkrab-test-mssql && docker rm dbkrab-test-mssql
-```
-
-## MSSQL 版本说明
-
-| 版本 | 容器镜像 | CDC 支持 | 限制 | 推荐用途 |
-|------|---------|---------|------|---------|
-| **Developer Edition** | `mssql/server:2022-latest` | ✅ 完整 | 无（功能同 Enterprise） | 测试/开发 ✅ |
-| **Express Edition** | `mssql/server:2019-GA-ubuntu-18.04` | ✅ 完整 | 数据库最大 4GB | 生产轻量部署 |
-| **Enterprise Edition** | 需自带 License | ✅ 完整 | 无 | 生产环境 |
-
-**测试环境推荐 Developer Edition**：
-- 免费
-- 功能完整（同 Enterprise）
-- 无数据库大小限制
-- CDC 功能与生产环境一致
-
-## 系统要求
-
-| 资源 | 要求 | 说明 |
-|------|------|------|
-| 内存 | 最少 2GB | MSSQL 容器占用约 1.5-2GB |
-| 磁盘 | 最少 5GB | 容器 + 测试数据 |
-| Docker | 20.10+ | 支持 Linux/macOS/Windows |
-
-## 故障排查
-
-### 容器启动失败
-
-```bash
-# 查看日志
-docker logs dbkrab-test-mssql
-
-# 检查端口占用
-sudo lsof -i :1433
-```
-
-### 测试连接失败
-
-```bash
-# 手动测试连接
-docker exec -it dbkrab-test-mssql /opt/mssql-tools/bin/sqlcmd \
-  -S localhost -U sa -P 'Test1234!' -Q "SELECT 1"
-```
-
-### CDC 未启用
-
-```bash
-# 检查数据库 CDC 状态
-docker exec -i dbkrab-test-mssql /opt/mssql-tools/bin/sqlcmd \
-  -S localhost -U sa -P 'Test1234!' \
-  -Q "SELECT name, is_cdc_enabled FROM sys.databases WHERE name = 'dbkrab_test'"
-```
+Mock driver 模拟的表：
+- `TestProducts` (ProductID, ProductName, Price, Stock)
+- `TestOrders` (OrderID, ProductID, Quantity, TotalAmount)
+- `TestOrderItems` (OrderItemID, OrderID, ItemName, ItemPrice)
 
 ## 测试用例
 
 | 测试 | 说明 |
 |------|------|
-| `TestCDCEnabled` | 验证 CDC 在数据库和表上启用 |
-| `TestChangeCapture` | 验证 INSERT/UPDATE 被 CDC 捕获 |
-| `TestCrossTableTransaction` | 验证跨表事务完整性 |
-| `TestLSNProgression` | 验证 LSN 正确递进 |
-| `TestConnectionRecovery` | 验证连接处理 |
-| `TestDataDirectory` | 验证数据目录可写 |
+| `TestMockMSSQLDriver` | 验证 Mock driver 基础查询功能 |
+| `TestMockCDCQuerier` | 验证 Mock CDCQuerier 接口 |
+| `TestMockCDCQuerierWithChanges` | 验证 CDC 变更数据返回 |
+| `TestIntegrationWithSQLite` | Mock MSSQL + 真实 SQLite 全链路集成 |
+| `TestMockMSQLWithRealPoller` | 验证与 Poller 组件接口兼容性 |
+| `TestCDCChangeTypes` | 验证 CDC 操作类型处理 |
+| `TestSQLiteStoreWrites` | 验证 SQLite 存储写入 |
 
 ## CI/CD
 
-GitHub Actions 会在 PR 时自动运行集成测试：
-- 使用 MSSQL service container
-- 自动执行 setup.sql
-- 运行所有集成测试
+GitHub Actions 和 pre-commit hook 都会自动运行集成测试：
 
-无需本地运行即可提交 PR，但建议本地验证后再推送。
+```bash
+# CI workflow (PR)
+go test -v -race ./...
+
+# Pre-commit hook
+make vet && make test && make lint
+```
+
+无需额外配置，所有测试在提交 PR 或本地 commit 时自动执行。


### PR DESCRIPTION
## Summary

- Remove `-skip Integration` from CI workflow test command
- Remove `-skip Integration` from Makefile `test` target
- Update `tests/integration/README.md` to reflect Mock driver usage

## Context

Integration tests now use Mock MSSQL driver (`mockmssql`), no Docker required.
All tests pass including integration tests (7 tests in `tests/integration` package).

## Test plan

- [x] `make test` passes locally (all tests including integration)
- [x] Pre-commit hook runs integration tests
- [ ] CI workflow will run integration tests on this PR

## Summary by Sourcery

Enable running integration tests across local development, pre-commit, and CI using a mock MSSQL driver instead of a real MSSQL instance.

New Features:
- Introduce mock MSSQL driver–based integration testing workflow that runs without Docker or a real MSSQL server.

Enhancements:
- Update integration test README to describe the mock MSSQL driver setup, test cases, and how tests run locally and in CI.
- Adjust the Makefile test target to include integration tests in the default test run.
- Update the CI workflow to run the full test suite including integration tests.

Tests:
- Ensure integration tests are executed by default via Makefile, pre-commit hook, and CI pipeline.