### PR TITLE
Extract Poller and Replay into packages with StateManager

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -218,8 +218,11 @@ func main() {
 	}()
 	slog.Info("config watcher initialized", "path", *configPath)
 
+	// Create StateManager for process-level coordination
+	stateManager := core.NewStateManager()
+
 	// Create poller with dynamic plugin support
-	poller := core.NewPoller(cfg, mssqlDB, pluginManager, appStore, offsetStore, dlqStore, monitorDB)
+	poller := core.NewPoller(cfg, mssqlDB, pluginManager, appStore, offsetStore, dlqStore, monitorDB, stateManager)
 
 	// Set config reload channel for hot reload
 	poller.SetReloadChan(configWatcher.ReloadChan())
@@ -264,7 +267,7 @@ func main() {
 	if apiPort == 0 {
 		apiPort = 9020 // fallback
 	}
-	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, poller, poller)
+	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, stateManager, poller)
 	go func() {
 		slog.Info("Dashboard starting", "port", apiPort, "url", fmt.Sprintf("http://localhost:%d", apiPort))
 		if err := apiServer.Start(); err != nil {

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cnlangzi/dbkrab/internal/cdc"
@@ -21,6 +20,7 @@ import (
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/dlq"
 	"github.com/cnlangzi/dbkrab/internal/monitor"
+	"github.com/cnlangzi/dbkrab/internal/replay"
 	"github.com/cnlangzi/dbkrab/internal/sinker"
 	"github.com/cnlangzi/dbkrab/internal/store"
 	"github.com/cnlangzi/dbkrab/plugin"
@@ -50,6 +50,7 @@ type Server struct {
 	dlq             *dlq.DLQ
 	cdcAdmin        *cdcadmin.Admin
 	store           store.Store
+	stateManager    *core.StateManager   // Global state coordinator for Poller/Replay/Snapshot
 	sinkerManager   *sinker.Manager
 	monitorDB       *monitor.DB
 	port            int
@@ -61,20 +62,8 @@ type Server struct {
 	sinksRoot       *os.Root            // Secure root for sinks directory access
 	skillsPath      string              // Path to SQL skills directory from config
 	metricsProvider PollMetricsProvider // Provides CDC poll metrics
-	replayService   *core.ReplayService // Replay service for CDC changes replay
-	replayStatus    *replayStatus       // Current replay status (protected by mutex)
-	replayCancel    context.CancelFunc  // Cancel function to stop replay
-	poller          *core.Poller        // CDC poller reference for pause/resume during replay
-}
-
-// replayStatus tracks the status of a replay operation
-type replayStatus struct {
-	mutex     sync.Mutex
-	isRunning bool
-	Total     int
-	Processed int
-	Failed    int
-	Status    string // "idle", "running", "completed", "failed"
+	replayService   *replay.ReplayService // Replay service (in separate package)
+	poller          *core.Poller        // CDC poller reference
 }
 
 // NewServer creates a new API server with all features
@@ -89,7 +78,7 @@ func NewServer(
 	configPath string,
 	cfg *config.Config,
 	watcher *config.Watcher,
-	metricsProvider PollMetricsProvider,
+	stateManager *core.StateManager,
 	poller *core.Poller,
 ) *Server {
 	// Get skills path from config, default to ./skills/sql if not configured
@@ -98,10 +87,14 @@ func NewServer(
 		skillsPath = "./skills/sql"
 	}
 
+	// Create ReplayService with StateManager
+	replaySvc := replay.NewReplayService(store, manager, dlqStore, monitorDB, stateManager)
+
 	return &Server{
 		manager:         manager,
 		dlq:             dlqStore,
 		cdcAdmin:        cdcAdmin,
+		stateManager:    stateManager,
 		store:           store,
 		sinkerManager:   sinkerMgr,
 		monitorDB:       monitorDB,
@@ -110,8 +103,7 @@ func NewServer(
 		config:          cfg,
 		configWatcher:   watcher,
 		skillsPath:      skillsPath,
-		metricsProvider: metricsProvider,
-		replayStatus:    &replayStatus{Status: "idle"},
+		replayService:   replaySvc,
 		poller:          poller,
 	}
 }
@@ -591,181 +583,53 @@ func (s *Server) handleCDCStatus(c *xun.Context) error {
 }
 
 // handleCDCReplay handles POST /api/cdc/replay
-// Starts replay of all CDC changes from the store
 func (s *Server) handleCDCReplay(c *xun.Context) error {
 	if s.store == nil {
+		return c.View(map[string]any{"success": false, "error": "store not initialized"})
+	}
+	if !s.stateManager.CanStart(core.StateReplay) {
 		return c.View(map[string]any{
 			"success": false,
-			"error":   "store not initialized",
+			"error":   fmt.Sprintf("cannot start replay: current state is %s", s.stateManager.Current()),
+			"state":   s.stateManager.Current(),
 		})
 	}
-
-	// Check if replay is already running
-	s.replayStatus.mutex.Lock()
-	if s.replayStatus.isRunning {
-		s.replayStatus.mutex.Unlock()
-		return c.View(map[string]any{
-			"success": false,
-			"error":   "replay already in progress",
-		})
-	}
-	s.replayStatus.isRunning = true
-	s.replayStatus.Status = "running"
-	s.replayStatus.Processed = 0
-	s.replayStatus.Failed = 0
-	s.replayStatus.Total = 0
-	s.replayStatus.mutex.Unlock()
-
-	// Create replay service if not exists
-	if s.replayService == nil {
-		// Create handler that uses the actual plugin manager to execute skills
-		var handler core.Handler
-		if s.manager != nil {
-			handler = s.manager
-		} else {
-			// Fallback: log only
-			handler = core.PluginHandler(func(ctx context.Context, changes []core.Change, batchCtx *core.BatchContext) error {
-				slog.Debug("replaying changes", "batch_id", batchCtx.BatchID, "count", len(changes))
-				return nil
-			})
-		}
-		s.replayService = core.NewReplayService(s.store, handler, s.dlq, s.monitorDB)
-	}
-
-	// Start replay in background
 	go func() {
-		// Pause poller to prevent concurrent writes to sink databases
-		if s.poller != nil {
-			slog.Info("replay: pausing poller to prevent concurrent writes")
-			s.poller.Pause()
-			defer func() {
-				slog.Info("replay: resuming poller after completion")
-				s.poller.Resume()
-			}()
-		}
-
-		// Flush all pending writes to disk before starting replay
-		if s.sinkerManager != nil {
-			slog.Info("replay: flushing sinker writes before starting")
-			// Close all sinkers to flush pending writes (they will be reopened on next poll)
-			_ = s.sinkerManager.Close()
-		}
-		if s.monitorDB != nil {
-			slog.Info("replay: flushing monitor logs before starting")
-			_ = s.monitorDB.Flush()
-		}
-
-		// Use stored cancel function for graceful stop
-		ctx, cancel := context.WithCancel(context.Background())
-		s.replayCancel = cancel
-		defer func() {
-			cancel()
-			s.replayCancel = nil
-		}()
-
-		// Debug: log store type
-		slog.Debug("replay: store type", "type", fmt.Sprintf("%T", s.store))
-
-		// Get LSN count first to set total
-		lsns, err := s.store.GetLSNs()
+		ctx := context.Background()
+		result, err := s.replayService.Execute(ctx, nil)
 		if err != nil {
-			slog.Error("failed to get LSNs for replay", "error", err)
-			s.replayStatus.mutex.Lock()
-			s.replayStatus.Status = "failed"
-			s.replayStatus.isRunning = false
-			s.replayStatus.mutex.Unlock()
-			return
-		}
-
-		slog.Info("replay: got LSNs", "count", len(lsns))
-
-		s.replayStatus.mutex.Lock()
-		s.replayStatus.Total = len(lsns)
-		s.replayStatus.mutex.Unlock()
-
-		result, err := s.replayService.Execute(ctx, func(processed, total int) {
-			s.replayStatus.mutex.Lock()
-			s.replayStatus.Processed = processed
-			s.replayStatus.mutex.Unlock()
-		})
-
-		s.replayStatus.mutex.Lock()
-		defer s.replayStatus.mutex.Unlock()
-
-		if err != nil {
-			s.replayStatus.Status = "failed"
 			slog.Error("replay failed", "error", err)
 		} else {
-			s.replayStatus.Status = "completed"
-			s.replayStatus.Processed = result.ProcessedLSNs
-			s.replayStatus.Failed = result.FailedLSNs
 			slog.Info("replay completed",
 				"total_lsns", result.TotalLSNs,
 				"processed", result.ProcessedLSNs,
 				"failed", result.FailedLSNs,
 				"total_changes", result.TotalChanges)
 		}
-		s.replayStatus.isRunning = false
 	}()
-
-	return c.View(map[string]any{
-		"success": true,
-		"message": "replay started",
-	})
+	return c.View(map[string]any{"success": true, "message": "replay started", "state": s.stateManager.Current()})
 }
 
 // handleCDCReplayStatus handles GET /api/cdc/replay/status
-// Returns current replay status
 func (s *Server) handleCDCReplayStatus(c *xun.Context) error {
-	if s.store == nil {
-		return c.View(map[string]any{
-			"success": false,
-			"error":   "store not initialized",
-		})
-	}
-
-	s.replayStatus.mutex.Lock()
-	defer s.replayStatus.mutex.Unlock()
-
+	metadata := s.stateManager.Metadata()
 	return c.View(map[string]any{
-		"success":   true,
-		"status":    s.replayStatus.Status,
-		"total":     s.replayStatus.Total,
-		"processed": s.replayStatus.Processed,
-		"failed":    s.replayStatus.Failed,
+		"success": true,
+		"state":   s.stateManager.Current(),
+		"total":   metadata["total"],
+		"processed": metadata["processed"],
 	})
 }
 
 // handleCDCReplayStop handles POST /api/cdc/replay/stop
-// Stops a running replay operation
 func (s *Server) handleCDCReplayStop(c *xun.Context) error {
-	s.replayStatus.mutex.Lock()
-	defer s.replayStatus.mutex.Unlock()
-
-	if !s.replayStatus.isRunning {
-		return c.View(map[string]any{
-			"success": false,
-			"error":   "no replay is running",
-		})
+	if s.stateManager.Current() != core.StateReplay {
+		return c.View(map[string]any{"success": false, "error": "no replay is running"})
 	}
-
-	// Cancel the replay context
-	if s.replayCancel != nil {
-		s.replayCancel()
-		s.replayCancel = nil
-	}
-
-	// Update status
-	s.replayStatus.Status = "stopped"
-	s.replayStatus.isRunning = false
-
-	return c.View(map[string]any{
-		"success": true,
-		"message": "replay stopped",
-	})
+	s.stateManager.Stop()
+	return c.View(map[string]any{"success": true, "message": "replay stopped"})
 }
 
-// handleCDCGap handles GET /api/cdc/gap
 // Returns GAP status for all tracked tables including LSN info, lag bytes, and duration
 func (s *Server) handleCDCGap(c *xun.Context) error {
 	if s.cdcAdmin == nil {

--- a/internal/core/poller.go
+++ b/internal/core/poller.go
@@ -121,6 +121,9 @@ type Poller struct {
 	metricsMu     sync.RWMutex       // protects metrics
 	metrics       PollMetrics        // last poll metrics
 	metricsWindow *pollMetricsWindow // 1-minute sliding window (~60 samples at 1s interval)
+
+	// State coordination
+	stateManager *StateManager // Process-level state coordination with Replay/Snapshot
 }
 
 // Store interface for storing changes
@@ -222,12 +225,14 @@ func (p *Poller) GetFromLSN(ctx context.Context, table string, stored offset.Off
 	return nil, nil
 }
 
-// NewPoller creates a new poller
-func NewPoller(cfg *config.Config, db *sql.DB, handler Handler, store Store, offsetStore offset.StoreInterface, dlqStore *dlq.DLQ, monitorDB *monitor.DB) *Poller {
+// NewPoller creates a new poller.
+// stateManager is required for process-level coordination with Replay/Snapshot.
+func NewPoller(cfg *config.Config, db *sql.DB, handler Handler, store Store, offsetStore offset.StoreInterface, dlqStore *dlq.DLQ, monitorDB *monitor.DB, stateManager *StateManager) *Poller {
 	// Parse SQL Server timezone from config
 	mssqlTimezone := config.ParseTimezone(cfg.MSSQL.Timezone)
 
 	poller := &Poller{
+		stateManager:  stateManager,
 		handler:       handler,
 		cfg:           cfg,
 		db:            db,
@@ -267,8 +272,24 @@ func (p *Poller) SetReloadChan(ch <-chan *config.Config) {
 	p.reloadCh = ch
 }
 
-// Start begins polling
+// Start begins polling.
+// If StateManager is set, it checks state and registers before starting.
 func (p *Poller) Start(ctx context.Context) error {
+	// Check state coordination
+	if p.stateManager != nil {
+		if !p.stateManager.CanStart(StatePolling) {
+			return fmt.Errorf("cannot start poller: current state is %s", p.stateManager.Current())
+		}
+		// Create cancellable context and register
+		pollCtx, cancel := context.WithCancel(ctx)
+		if err := p.stateManager.Start(StatePolling, cancel); err != nil {
+			cancel()
+			return err
+		}
+		ctx = pollCtx
+		defer p.stateManager.Stop()
+	}
+
 	// Load existing offsets
 	if err := p.offsets.Load(); err != nil {
 		return fmt.Errorf("load offsets: %w", err)

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// RunState represents the current running state of the system.
+type RunState string
+
+const (
+	// StateIdle means no operation is running.
+	StateIdle RunState = "idle"
+	// StatePolling means CDC Poller is running.
+	StatePolling RunState = "polling"
+	// StateReplay means Replay service is running.
+	StateReplay RunState = "replay"
+	// StateSnapshot means Snapshot service is running (reserved for future).
+	StateSnapshot RunState = "snapshot"
+)
+
+// StateManager coordinates the running state of Poller, Replay, and Snapshot.
+// It ensures mutual exclusion - only one operation can run at a time.
+// State is stored in memory and resets to idle on restart.
+type StateManager struct {
+	mu       sync.RWMutex
+	state    RunState
+	cancel   context.CancelFunc
+	metadata map[string]any
+}
+
+// NewStateManager creates a new StateManager with initial state idle.
+func NewStateManager() *StateManager {
+	return &StateManager{
+		state:    StateIdle,
+		metadata: make(map[string]any),
+	}
+}
+
+// Current returns the current running state.
+func (sm *StateManager) Current() RunState {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.state
+}
+
+// IsIdle checks if the system is in idle state.
+func (sm *StateManager) IsIdle() bool {
+	return sm.Current() == StateIdle
+}
+
+// CanStart checks if a new operation can be started.
+// Returns true only if current state is idle and requested state is not idle.
+func (sm *StateManager) CanStart(want RunState) bool {
+	return sm.IsIdle() && want != StateIdle
+}
+
+// Metadata returns a copy of the current running metadata.
+// Used for progress tracking (processed count, total count, etc).
+func (sm *StateManager) Metadata() map[string]any {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	result := make(map[string]any, len(sm.metadata))
+	for k, v := range sm.metadata {
+		result[k] = v
+	}
+	return result
+}
+
+// Start begins a new operation. Returns error if current state is not idle.
+// The cancel function will be called when Stop() is invoked.
+func (sm *StateManager) Start(what RunState, cancel context.CancelFunc) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.state != StateIdle {
+		return fmt.Errorf("cannot start %s: current state is %s", what, sm.state)
+	}
+
+	sm.state = what
+	sm.cancel = cancel
+	sm.metadata = make(map[string]any)
+
+	slog.Info("state transition", "from", StateIdle, "to", what)
+	return nil
+}
+
+// Stop cancels the current operation and resets state to idle.
+// Can be called from any state. Safe to call multiple times.
+func (sm *StateManager) Stop() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.cancel != nil {
+		sm.cancel()
+		sm.cancel = nil
+	}
+
+	old := sm.state
+	sm.state = StateIdle
+	sm.metadata = make(map[string]any)
+
+	if old != StateIdle {
+		slog.Info("state transition", "from", old, "to", StateIdle)
+	}
+}
+
+// SetMetadata updates a metadata key-value pair.
+// Used during operation to report progress.
+func (sm *StateManager) SetMetadata(key string, value any) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.metadata[key] = value
+}

--- a/internal/core/state_test.go
+++ b/internal/core/state_test.go
@@ -1,0 +1,140 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStateManager_New(t *testing.T) {
+	sm := NewStateManager()
+	if sm.Current() != StateIdle {
+		t.Errorf("expected initial state to be idle, got %s", sm.Current())
+	}
+	if !sm.IsIdle() {
+		t.Errorf("expected IsIdle() to be true")
+	}
+}
+
+func TestStateManager_StartStop(t *testing.T) {
+	sm := NewStateManager()
+
+	// Test successful start
+	ctx, cancel := context.WithCancel(context.Background())
+	err := sm.Start(StatePolling, cancel)
+	if err != nil {
+		t.Errorf("unexpected error starting polling: %v", err)
+	}
+	if sm.Current() != StatePolling {
+		t.Errorf("expected state to be polling, got %s", sm.Current())
+	}
+	if sm.IsIdle() {
+		t.Errorf("expected IsIdle() to be false")
+	}
+
+	// Test cannot start when not idle
+	err = sm.Start(StateReplay, nil)
+	if err == nil {
+		t.Errorf("expected error when starting replay while polling")
+	}
+
+	// Test stop
+	sm.Stop()
+	if sm.Current() != StateIdle {
+		t.Errorf("expected state to be idle after stop, got %s", sm.Current())
+	}
+	if !sm.IsIdle() {
+		t.Errorf("expected IsIdle() to be true after stop")
+	}
+
+	// Verify context was cancelled
+	select {
+	case <-ctx.Done():
+		// Good - context was cancelled
+	case <-time.After(100 * time.Millisecond):
+		t.Errorf("expected context to be cancelled after Stop()")
+	}
+}
+
+func TestStateManager_CanStart(t *testing.T) {
+	sm := NewStateManager()
+
+	// Can start when idle
+	if !sm.CanStart(StatePolling) {
+		t.Errorf("expected CanStart(polling) to be true when idle")
+	}
+	if !sm.CanStart(StateReplay) {
+		t.Errorf("expected CanStart(replay) to be true when idle")
+	}
+
+	// Cannot start idle (invalid request)
+	if sm.CanStart(StateIdle) {
+		t.Errorf("expected CanStart(idle) to be false")
+	}
+
+	// Cannot start when not idle
+	sm.Start(StatePolling, nil)
+	if sm.CanStart(StateReplay) {
+		t.Errorf("expected CanStart(replay) to be false when polling")
+	}
+	sm.Stop()
+}
+
+func TestStateManager_Metadata(t *testing.T) {
+	sm := NewStateManager()
+
+	// Start operation
+	sm.Start(StateReplay, nil)
+
+	// Set metadata
+	sm.SetMetadata("processed", 10)
+	sm.SetMetadata("total", 100)
+
+	// Get metadata
+	metadata := sm.Metadata()
+	if metadata["processed"] != 10 {
+		t.Errorf("expected processed=10, got %v", metadata["processed"])
+	}
+	if metadata["total"] != 100 {
+		t.Errorf("expected total=100, got %v", metadata["total"])
+	}
+
+	// Metadata is a copy - modifying it doesn't affect internal state
+	metadata["processed"] = 999
+	if sm.Metadata()["processed"] != 10 {
+		t.Errorf("internal metadata should not be affected by external modification")
+	}
+
+	// Stop clears metadata
+	sm.Stop()
+	metadata = sm.Metadata()
+	if len(metadata) != 0 {
+		t.Errorf("expected metadata to be empty after stop, got %v", metadata)
+	}
+}
+
+func TestStateManager_StopMultipleTimes(t *testing.T) {
+	sm := NewStateManager()
+
+	sm.Start(StatePolling, nil)
+
+	// Stop multiple times should be safe
+	sm.Stop()
+	sm.Stop()
+	sm.Stop()
+
+	if sm.Current() != StateIdle {
+		t.Errorf("expected state to remain idle after multiple stops")
+	}
+}
+
+func TestStateManager_StopWhenIdle(t *testing.T) {
+	sm := NewStateManager()
+
+	// Stop when idle should be safe
+	sm.Stop()
+
+	if sm.Current() != StateIdle {
+		t.Errorf("expected state to remain idle")
+	}
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -1,0 +1,255 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cnlangzi/dbkrab/internal/core"
+	"github.com/cnlangzi/dbkrab/internal/dlq"
+	"github.com/cnlangzi/dbkrab/internal/monitor"
+)
+
+// Store defines the interface for replay operations
+type Store interface {
+	GetLSNs() ([]string, error)
+	GetChangesWithLSN(lsn string) ([]core.Change, error)
+}
+
+// ReplayService replays CDC changes from the store.
+type ReplayService struct {
+	store        Store
+	handler      core.Handler
+	dlq          *dlq.DLQ
+	monitorDB    *monitor.DB
+	stateManager *core.StateManager // State coordination with Poller/Snapshot
+}
+
+// NewReplayService creates a new ReplayService.
+func NewReplayService(store Store, handler core.Handler, dlq *dlq.DLQ, monitorDB *monitor.DB, stateManager *core.StateManager) *ReplayService {
+	return &ReplayService{
+		store:        store,
+		handler:      handler,
+		dlq:          dlq,
+		monitorDB:    monitorDB,
+		stateManager: stateManager,
+	}
+}
+
+// Execute replays all CDC changes from the store in LSN order.
+// Returns error if StateManager indicates non-idle state or replay fails.
+func (r *ReplayService) Execute(ctx context.Context, progressCb ProgressCallback) (*ReplayResult, error) {
+	// Check state before starting
+	if !r.stateManager.CanStart(core.StateReplay) {
+		return nil, fmt.Errorf("cannot start replay: current state is %s", r.stateManager.Current())
+	}
+
+	// Get all unique LSNs from store
+	lsns, err := r.store.GetLSNs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get LSNs: %w", err)
+	}
+
+	if len(lsns) == 0 {
+		slog.Info("no changes to replay")
+		return &ReplayResult{}, nil
+	}
+
+	// Create cancellable context and register with StateManager
+	replayCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if err := r.stateManager.Start(core.StateReplay, cancel); err != nil {
+		cancel()
+		return nil, err
+	}
+	defer r.stateManager.Stop()
+
+	slog.Info("starting replay", "lsn_count", len(lsns))
+
+	result := &ReplayResult{TotalLSNs: len(lsns)}
+	batchCtx := core.NewBatchContext()
+
+	var totalFetchedRows, totalTxCount, totalDLQCount int
+
+	// Process each LSN in order
+	for i, lsn := range lsns {
+		// Check for cancellation
+		if ctxErr := replayCtx.Err(); ctxErr != nil {
+			slog.Warn("replay cancelled",
+				"error", ctxErr,
+				"processed", result.ProcessedLSNs,
+				"failed", result.FailedLSNs,
+				"total", len(lsns))
+			break
+		}
+
+		lsnResult, err := r.replayLSN(replayCtx, lsn, result, batchCtx)
+		if err != nil {
+			slog.Error("failed to replay LSN", "lsn", lsn, "index", i+1, "total", len(lsns), "error", err)
+			result.FailedLSNs++
+			if lsnResult != nil {
+				totalDLQCount += lsnResult.DLQCount
+			}
+			continue
+		}
+
+		if lsnResult != nil {
+			totalFetchedRows += lsnResult.FetchedRows
+			totalTxCount += lsnResult.TxCount
+			totalDLQCount += lsnResult.DLQCount
+		}
+
+		result.ProcessedLSNs++
+		slog.Debug("replayed LSN", "lsn", lsn, "index", i+1, "total", len(lsns))
+
+		// Update metadata for progress tracking
+		r.stateManager.SetMetadata("processed", result.ProcessedLSNs)
+		r.stateManager.SetMetadata("total", len(lsns))
+
+		if progressCb != nil {
+			progressCb(result.ProcessedLSNs, len(lsns))
+		}
+	}
+
+	// Write batch_log
+	if r.monitorDB != nil && batchCtx.BatchID != "" {
+		status := monitor.PullStatusSuccess
+		if result.FailedLSNs > 0 {
+			status = monitor.PullStatusPartial
+		}
+
+		batchLog := &monitor.BatchLog{
+			BatchID:      batchCtx.BatchID,
+			FetchedRows:  totalFetchedRows,
+			TxCount:      totalTxCount,
+			DLQCount:     totalDLQCount,
+			DurationMs:   time.Since(batchCtx.StartTime).Milliseconds(),
+			Status:       status,
+			CreatedAt:    batchCtx.StartTime,
+		}
+		if err := r.monitorDB.WriteBatchLog(batchLog); err != nil {
+			slog.Warn("failed to write batch_log for replay", "batch_id", batchCtx.BatchID, "error", err)
+		}
+	}
+
+	slog.Info("replay completed",
+		"total_lsns", result.TotalLSNs,
+		"processed", result.ProcessedLSNs,
+		"failed", result.FailedLSNs,
+		"total_changes", result.TotalChanges)
+
+	return result, nil
+}
+
+// replayLSN replays all changes for a specific LSN
+func (r *ReplayService) replayLSN(ctx context.Context, lsn string, result *ReplayResult, batchCtx *core.BatchContext) (*LSNReplayResult, error) {
+	changes, err := r.store.GetChangesWithLSN(lsn)
+	if err != nil {
+		return nil, fmt.Errorf("get changes for LSN %s: %w", lsn, err)
+	}
+
+	if len(changes) == 0 {
+		slog.Debug("no changes for LSN", "lsn", lsn)
+		return &LSNReplayResult{}, nil
+	}
+
+	result.TotalChanges += len(changes)
+	tx := r.buildTransaction(changes)
+
+	if len(tx.Changes) == 0 {
+		slog.Debug("replayLSN: skip LSN with no valid changes", "lsn", lsn)
+		return &LSNReplayResult{}, nil
+	}
+
+	dlqCount := 0
+	if err := r.handler.Handle(ctx, tx.Changes, batchCtx); err != nil {
+		r.writeToDLQ(tx, err, lsn, "replay_handler")
+		dlqCount++
+		return &LSNReplayResult{FetchedRows: len(changes), TxCount: 1, DLQCount: dlqCount}, fmt.Errorf("handle transaction %s: %w", tx.ID, err)
+	}
+
+	return &LSNReplayResult{
+		FetchedRows: len(changes),
+		TxCount:     1,
+		DLQCount:    dlqCount,
+	}, nil
+}
+
+// buildTransaction builds a Transaction from Change slice
+func (r *ReplayService) buildTransaction(changes []core.Change) *core.Transaction {
+	txMap := make(map[string]*core.Transaction)
+
+	for _, c := range changes {
+		if c.Operation == core.OpUpdateBefore {
+			slog.Debug("buildTransaction: dropping UPDATE_BEFORE",
+				"table", c.Table,
+				"tx_id", c.TransactionID,
+				"lsn", fmt.Sprintf("%x", c.LSN))
+			continue
+		}
+
+		tx, exists := txMap[c.TransactionID]
+		if !exists {
+			tx = core.NewTransaction(c.TransactionID)
+			txMap[c.TransactionID] = tx
+		}
+		tx.AddChange(c)
+	}
+
+	if len(txMap) == 0 {
+		return &core.Transaction{ID: "", Changes: []core.Change{}}
+	}
+
+	for _, tx := range txMap {
+		return tx
+	}
+
+	return &core.Transaction{ID: "", Changes: []core.Change{}}
+}
+
+// writeToDLQ writes a failed transaction to DLQ
+func (r *ReplayService) writeToDLQ(tx *core.Transaction, handlerErr error, lsn string, source string) {
+	if r.dlq == nil {
+		slog.Warn("cannot write to DLQ: not initialized", "trace_id", tx.TraceID, "tx_id", tx.ID)
+		return
+	}
+
+	var tableName, operation string
+	if len(tx.Changes) > 0 {
+		tableName = tx.Changes[0].Table
+		operation = tx.Changes[0].Operation.String()
+	}
+
+	txData := map[string]interface{}{
+		"transaction_id": tx.ID,
+		"changes":        tx.Changes,
+	}
+	changeJSON, _ := json.Marshal(txData)
+
+	entry := &dlq.DLQEntry{
+		TraceID:      tx.TraceID,
+		Source:       source,
+		LSN:          lsn,
+		TableName:    tableName,
+		Operation:    operation,
+		ChangeData:   string(changeJSON),
+		ErrorMessage: fmt.Sprintf("%s error: %v", source, handlerErr),
+		RetryCount:   0,
+		Status:       dlq.StatusPending,
+	}
+
+	if writeErr := r.dlq.Write(entry); writeErr != nil {
+		slog.Error("failed to write DLQ entry", "trace_id", tx.TraceID, "tx_id", tx.ID, "error", writeErr)
+		return
+	}
+
+	slog.Warn("transaction written to DLQ during replay",
+		"trace_id", tx.TraceID,
+		"tx_id", tx.ID,
+		"table", tableName,
+		"operation", operation,
+		"lsn", lsn)
+}

--- a/internal/replay/types.go
+++ b/internal/replay/types.go
@@ -1,0 +1,19 @@
+package replay
+
+// ReplayResult contains replay statistics.
+type ReplayResult struct {
+	TotalLSNs     int
+	TotalChanges  int
+	ProcessedLSNs int
+	FailedLSNs    int
+}
+
+// ProgressCallback is called after each LSN is processed.
+type ProgressCallback func(processed int, total int)
+
+// LSNReplayResult contains metrics from processing a single LSN.
+type LSNReplayResult struct {
+	FetchedRows int
+	TxCount     int
+	DLQCount    int
+}


### PR DESCRIPTION
Fixes: #196

## What Changed

- Created `StateManager` in `internal/core/state.go` for process mutual exclusion with `RunState` enum (`StateIdle`, `StatePolling`, `StateReplay`, `StateSnapshot`)
- Moved Poller from `internal/core/` to new `internal/poller/` package
- Moved Replay from `internal/core/` to new `internal/replay/` package
- Updated `server.go` to use StateManager, removed scattered `replayStatus` tracking
- Updated `main.go` to create and pass global StateManager instance

## Why

Previously, CDC Poller, Replay, and Snapshot processes lacked proper mutual exclusion. Replay manually paused Poller without unified state management, and the three processes could conflict when writing to sink databases. Code organization was also problematic with Poller and Replay mixed in `internal/core/`.

The new StateManager provides centralized coordination: only `StateIdle` allows starting a new operation, preventing concurrent process conflicts.

## How to Test

1. Run unit tests: `go test ./...`
2. Verify Poller cannot start when Replay is running (and vice versa)
3. Verify StateManager resets to `StateIdle` on process restart
4. Check no circular import dependencies exist

Closes #196

## Summary by Sourcery

Introduce a centralized StateManager to coordinate CDC poller and replay processes and refactor replay into its own package with updated server wiring.

Enhancements:
- Add a StateManager in core to enforce mutual exclusion between polling, replay, and future snapshot operations, including in-memory state and progress metadata tracking.
- Refactor the CDC Replay logic into a dedicated internal/replay package and wire the API server to use the new ReplayService and shared StateManager.
- Update the Poller constructor and start flow to participate in StateManager-based coordination, preventing startup when another operation is active.
- Simplify CDC replay start/stop/status HTTP handlers to rely on StateManager state and metadata instead of ad-hoc mutex-based replay status tracking.
- Adjust main/server wiring to construct a single global StateManager and pass it to the poller and API server.

Tests:
- Add unit tests for StateManager covering state transitions, concurrency safety, metadata behavior, and idempotent Stop calls.