### PR TITLE
feat: add Snapshot dashboard page with progress tracking

### DIFF
--- a/cmd/app/dashboard/layouts/dashboard.html
+++ b/cmd/app/dashboard/layouts/dashboard.html
@@ -203,6 +203,16 @@
                         </a>
                     </div>
                 </div>
+
+                <!-- Snapshot Section -->
+                <a href="/snapshot" data-tab="snapshot"
+                   class="flex items-center gap-3 px-4 py-3 text-textMuted hover:bg-surface hover:text-text transition-colors sidebar-link">
+                    <!-- Snapshot Icon -->
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+                    </svg>
+                    <span>Snapshot</span>
+                </a>
             </nav>
 
             <!-- Footer -->

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -267,7 +267,7 @@ func main() {
 	if apiPort == 0 {
 		apiPort = 9020 // fallback
 	}
-	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, stateManager, poller)
+	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, stateManager, poller, mssqlDB)
 	go func() {
 		slog.Info("Dashboard starting", "port", apiPort, "url", fmt.Sprintf("http://localhost:%d", apiPort))
 		if err := apiServer.Start(); err != nil {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -267,7 +267,7 @@ func main() {
 	if apiPort == 0 {
 		apiPort = 9020 // fallback
 	}
-	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, stateManager, poller, mssqlDB)
+	apiServer := NewServer(pluginManager, dlqStore, cdcAdmin, appStore, sinkerMgr, monitorDB, apiPort, *configPath, cfg, configWatcher, stateManager, poller, offsetStore, mssqlDB)
 	go func() {
 		slog.Info("Dashboard starting", "port", apiPort, "url", fmt.Sprintf("http://localhost:%d", apiPort))
 		if err := apiServer.Start(); err != nil {

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/dlq"
 	"github.com/cnlangzi/dbkrab/internal/monitor"
+	"github.com/cnlangzi/dbkrab/internal/offset"
 	"github.com/cnlangzi/dbkrab/internal/replay"
 	"github.com/cnlangzi/dbkrab/internal/sinker"
 	"github.com/cnlangzi/dbkrab/internal/snapshot"
@@ -83,6 +84,7 @@ func NewServer(
 	watcher *config.Watcher,
 	stateManager *core.StateManager,
 	poller *core.Poller,
+	offsetStore offset.StoreInterface,
 	db *sql.DB,
 ) *Server {
 	// Get skills path from config, default to ./skills/sql if not configured
@@ -109,7 +111,7 @@ func NewServer(
 		skillsPath:      skillsPath,
 		replayService:   replaySvc,
 		poller:          poller,
-		snapshotService: snapshot.NewSnapshotService(stateManager, db, time.Local, nil, sinkerMgr),
+		snapshotService: snapshot.NewSnapshotService(stateManager, db, time.Local, offsetStore, sinkerMgr),
 	}
 }
 
@@ -1510,6 +1512,11 @@ func (s *Server) handleSnapshotStart(c *xun.Context) error {
 				})
 			}
 		}
+	}
+
+	// Guard against empty table list
+	if len(tables) == 0 {
+		return c.View(map[string]any{"success": false, "error": "no CDC tables configured"})
 	}
 
 	// Start snapshot

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	"github.com/cnlangzi/dbkrab/internal/monitor"
 	"github.com/cnlangzi/dbkrab/internal/replay"
 	"github.com/cnlangzi/dbkrab/internal/sinker"
+	"github.com/cnlangzi/dbkrab/internal/snapshot"
 	"github.com/cnlangzi/dbkrab/internal/store"
 	"github.com/cnlangzi/dbkrab/plugin"
 	"github.com/yaitoo/xun"
@@ -64,6 +66,7 @@ type Server struct {
 	metricsProvider PollMetricsProvider // Provides CDC poll metrics
 	replayService   *replay.ReplayService // Replay service (in separate package)
 	poller          *core.Poller        // CDC poller reference
+	snapshotService *snapshot.SnapshotService   // Snapshot service
 }
 
 // NewServer creates a new API server with all features
@@ -80,6 +83,7 @@ func NewServer(
 	watcher *config.Watcher,
 	stateManager *core.StateManager,
 	poller *core.Poller,
+	db *sql.DB,
 ) *Server {
 	// Get skills path from config, default to ./skills/sql if not configured
 	skillsPath := cfg.Plugins.SQL.Path
@@ -105,6 +109,7 @@ func NewServer(
 		skillsPath:      skillsPath,
 		replayService:   replaySvc,
 		poller:          poller,
+		snapshotService: snapshot.NewSnapshotService(stateManager, db, time.Local, nil, sinkerMgr),
 	}
 }
 
@@ -210,6 +215,16 @@ func (s *Server) registerAPIRoutes() {
 		slog.Info("CDC changes/status routes registered")
 	} else {
 		slog.Warn("CDC changes/status routes skipped - store is nil")
+	}
+
+	// Snapshot routes
+	if s.snapshotService != nil {
+		api.Post("/snapshot/start", s.handleSnapshotStart, xun.WithViewer(&xun.JsonViewer{}))
+		api.Get("/snapshot/status", s.handleSnapshotStatus, xun.WithViewer(&xun.JsonViewer{}))
+		api.Get("/snapshot/tables", s.handleSnapshotTables, xun.WithViewer(&xun.JsonViewer{}))
+		slog.Info("Snapshot routes registered")
+	} else {
+		slog.Warn("Snapshot routes skipped - snapshot service is nil")
 	}
 
 	// CDC gap monitoring routes
@@ -1474,4 +1489,77 @@ func (s *Server) handleMonitorSinks(c *xun.Context) error {
 	}
 
 	return c.View(map[string]any{"success": true, "logs": logs})
+}
+
+// handleSnapshotStart handles POST /api/snapshot/start - starts a snapshot operation
+func (s *Server) handleSnapshotStart(c *xun.Context) error {
+	if s.snapshotService == nil {
+		return c.View(map[string]any{"success": false, "error": "snapshot service not initialized"})
+	}
+
+	// Get CDC tables from config
+	var tables []snapshot.CDCTable
+	if s.configWatcher != nil {
+		cfg := s.configWatcher.Get()
+		for _, t := range cfg.Tables {
+			parts := strings.SplitN(t, ".", 2)
+			if len(parts) == 2 {
+				tables = append(tables, snapshot.CDCTable{
+					Schema: parts[0],
+					Name:   parts[1],
+				})
+			}
+		}
+	}
+
+	// Start snapshot
+	err := s.snapshotService.Start(context.Background(), tables)
+	if err != nil {
+		return c.View(map[string]any{"success": false, "error": err.Error()})
+	}
+
+	return c.View(map[string]any{"success": true, "message": "snapshot started"})
+}
+
+// handleSnapshotStatus handles GET /api/snapshot/status - returns current snapshot progress
+func (s *Server) handleSnapshotStatus(c *xun.Context) error {
+	if s.snapshotService == nil {
+		return c.View(map[string]any{"success": false, "error": "snapshot service not initialized"})
+	}
+
+	progress := s.snapshotService.GetProgress()
+	return c.View(map[string]any{
+		"success": true,
+		"state":   progress.State,
+		"tables":  progress.Tables,
+		"processed": progress.Processed,
+		"current_table": progress.CurrentTable,
+		"current_rows": progress.CurrentRows,
+		"current_total": progress.CurrentTotal,
+		"error": progress.Error,
+		"started_at": progress.StartedAt,
+		"completed_at": progress.CompletedAt,
+	})
+}
+
+// handleSnapshotTables handles GET /api/snapshot/tables - returns list of CDC tables
+func (s *Server) handleSnapshotTables(c *xun.Context) error {
+	if s.configWatcher == nil {
+		return c.View(map[string]any{"success": false, "error": "config not available"})
+	}
+
+	cfg := s.configWatcher.Get()
+	tables := make([]map[string]string, 0, len(cfg.Tables))
+	for _, t := range cfg.Tables {
+		parts := strings.SplitN(t, ".", 2)
+		if len(parts) == 2 {
+			tables = append(tables, map[string]string{
+				"schema": parts[0],
+				"name":  parts[1],
+				"full":  t,
+			})
+		}
+	}
+
+	return c.View(map[string]any{"success": true, "count": len(tables), "tables": tables})
 }

--- a/internal/sinker/sinker.go
+++ b/internal/sinker/sinker.go
@@ -18,6 +18,9 @@ type Sinker interface {
 	// Write writes a batch of sink operations to the sink with context for timeout/cancellation
 	Write(ctx context.Context, ops []core.Sink) error
 
+	// ExecContext executes a raw SQL query (used for table maintenance like TRUNCATE/DELETE)
+	ExecContext(ctx context.Context, query string) error
+
 	// Migrate runs the migration for this sinker's database.
 	// It re-discovers and re-applies migrations from the configured migrations path.
 	Migrate(ctx context.Context) error

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -79,6 +79,12 @@ func (s *Sinker) Write(ctx context.Context, ops []core.Sink) error {
 	return nil
 }
 
+// ExecContext executes a raw SQL query
+func (s *Sinker) ExecContext(ctx context.Context, query string) error {
+	_, err := s.db.Writer.ExecContext(ctx, query)
+	return err
+}
+
 func (s *Sinker) writeOp(ctx context.Context, tx sqliteutil.TxExec, op core.Sink) error {
 	config := sqliteutil.TableConfig{
 		Output:     op.Config.Output,

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -91,8 +91,8 @@ func (s *SnapshotService) Start(ctx context.Context, tables []CDCTable) error {
 	}
 	s.mu.Unlock()
 
-	// Create cancellable context
-	ctx, cancel := context.WithCancel(context.Background())
+	// Create cancellable context based on the passed-in context
+	ctx, cancel := context.WithCancel(ctx)
 	s.mu.Lock()
 	s.cancelFunc = cancel
 	s.mu.Unlock()

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cnlangzi/dbkrab/internal/config"
 	"github.com/cnlangzi/dbkrab/internal/core"
+	"github.com/cnlangzi/dbkrab/internal/offset"
 	"github.com/cnlangzi/dbkrab/internal/sinker"
 )
 
@@ -30,11 +31,11 @@ type SnapshotProgress struct {
 
 // SnapshotService manages snapshot operations with singleton behavior.
 type SnapshotService struct {
-	mu           sync.Mutex
+	mu           sync.RWMutex
 	running      bool
 	stateManager *core.StateManager
 	querier      *Querier
-	offsetStore  OffsetUpdater
+	offsetStore  offset.StoreInterface
 	sinkerMgr    *sinker.Manager
 	db           *sql.DB
 	progress     SnapshotProgress
@@ -46,7 +47,7 @@ func NewSnapshotService(
 	stateManager *core.StateManager,
 	db *sql.DB,
 	timezone *time.Location,
-	offsetStore OffsetUpdater,
+	offsetStore offset.StoreInterface,
 	sinkerMgr *sinker.Manager,
 ) *SnapshotService {
 	querier := NewQuerier(db, timezone, nil)
@@ -62,8 +63,8 @@ func NewSnapshotService(
 
 // GetProgress returns the current snapshot progress.
 func (s *SnapshotService) GetProgress() SnapshotProgress {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.progress
 }
 
@@ -91,14 +92,14 @@ func (s *SnapshotService) Start(ctx context.Context, tables []CDCTable) error {
 	}
 	s.mu.Unlock()
 
-	// Create cancellable context based on the passed-in context
-	ctx, cancel := context.WithCancel(ctx)
+	// Create cancellable context detached from HTTP/2 request context
+	_, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
 	s.cancelFunc = cancel
 	s.mu.Unlock()
 
 	// Run snapshot in background
-	go s.runSnapshot(ctx, tables)
+	go s.runSnapshot(context.Background(), tables)
 
 	return nil
 }
@@ -335,14 +336,16 @@ type CDCTable struct {
 // GetCDCTables returns the list of CDC-enabled tables from config.
 func GetCDCTables(cfg *config.Config) []CDCTable {
 	tables := make([]CDCTable, 0, len(cfg.Tables))
-	for _, t := range cfg.Tables {
+	for i, t := range cfg.Tables {
 		parts := strings.SplitN(t, ".", 2)
-		if len(parts) == 2 {
-			tables = append(tables, CDCTable{
-				Schema: parts[0],
-				Name:   parts[1],
-			})
+		if len(parts) != 2 {
+			slog.Warn("snapshot: skipped malformed table entry", "index", i, "entry", t)
+			continue
 		}
+		tables = append(tables, CDCTable{
+			Schema: parts[0],
+			Name:   parts[1],
+		})
 	}
 	return tables
 }

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -1,0 +1,348 @@
+package snapshot
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cnlangzi/dbkrab/internal/config"
+	"github.com/cnlangzi/dbkrab/internal/core"
+	"github.com/cnlangzi/dbkrab/internal/sinker"
+)
+
+// SnapshotProgress holds the current state of a snapshot operation.
+type SnapshotProgress struct {
+	State        string `json:"state"`         // "idle", "running", "completed", "failed"
+	Tables       int    `json:"tables"`        // Total table count
+	Processed     int    `json:"processed"`    // Completed tables count
+	CurrentTable  string `json:"current_table"` // Currently processing table name
+	CurrentRows   int    `json:"current_rows"`  // Rows processed in current table
+	CurrentTotal  int    `json:"current_total"` // Total rows in current table
+	Error         string `json:"error"`         // Error message if failed
+	StartedAt     string `json:"started_at"`    // Start time
+	CompletedAt   string `json:"completed_at"`  // Completion time
+}
+
+// SnapshotService manages snapshot operations with singleton behavior.
+type SnapshotService struct {
+	mu           sync.Mutex
+	running      bool
+	stateManager *core.StateManager
+	querier      *Querier
+	offsetStore  OffsetUpdater
+	sinkerMgr    *sinker.Manager
+	db           *sql.DB
+	progress     SnapshotProgress
+	cancelFunc   context.CancelFunc
+}
+
+// NewSnapshotService creates a new SnapshotService.
+func NewSnapshotService(
+	stateManager *core.StateManager,
+	db *sql.DB,
+	timezone *time.Location,
+	offsetStore OffsetUpdater,
+	sinkerMgr *sinker.Manager,
+) *SnapshotService {
+	querier := NewQuerier(db, timezone, nil)
+	return &SnapshotService{
+		stateManager: stateManager,
+		querier:      querier,
+		offsetStore:  offsetStore,
+		sinkerMgr:    sinkerMgr,
+		db:           db,
+		progress:     SnapshotProgress{State: "idle"},
+	}
+}
+
+// GetProgress returns the current snapshot progress.
+func (s *SnapshotService) GetProgress() SnapshotProgress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.progress
+}
+
+// Start starts a snapshot for all CDC-enabled tables.
+// Returns error if snapshot is already running.
+func (s *SnapshotService) Start(ctx context.Context, tables []CDCTable) error {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return fmt.Errorf("snapshot already running")
+	}
+	s.running = true
+	s.mu.Unlock()
+
+	// Set state to snapshot (poller will detect and skip)
+	s.stateManager.Set(core.StateSnapshot)
+
+	// Initialize progress
+	s.mu.Lock()
+	s.progress = SnapshotProgress{
+		State:    "running",
+		Tables:   len(tables),
+		Processed: 0,
+		StartedAt: time.Now().Format(time.RFC3339),
+	}
+	s.mu.Unlock()
+
+	// Create cancellable context
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.cancelFunc = cancel
+	s.mu.Unlock()
+
+	// Run snapshot in background
+	go s.runSnapshot(ctx, tables)
+
+	return nil
+}
+
+// runSnapshot executes the snapshot operation in a goroutine.
+func (s *SnapshotService) runSnapshot(ctx context.Context, tables []CDCTable) {
+	defer func() {
+		s.mu.Lock()
+		s.running = false
+		s.cancelFunc = nil
+		s.mu.Unlock()
+		s.stateManager.Set(core.StateIdle)
+	}()
+
+	slog.Info("snapshot: starting", "table_count", len(tables))
+
+	// Step 1: Clear all sink tables
+	if err := s.clearSinkTables(ctx, tables); err != nil {
+		s.mu.Lock()
+		s.progress.State = "failed"
+		s.progress.Error = fmt.Sprintf("clear sink tables: %v", err)
+		s.mu.Unlock()
+		slog.Error("snapshot: failed to clear sink tables", "error", err)
+		return
+	}
+
+	// Step 2: Run snapshot for each table
+	for i, table := range tables {
+		// Check for cancellation
+		select {
+		case <-ctx.Done():
+			s.mu.Lock()
+			s.progress.State = "failed"
+			s.progress.Error = "cancelled"
+			s.mu.Unlock()
+			return
+		default:
+		}
+
+		s.mu.Lock()
+		s.progress.CurrentTable = fmt.Sprintf("%s.%s", table.Schema, table.Name)
+		s.mu.Unlock()
+
+		slog.Info("snapshot: processing table", "table", s.progress.CurrentTable, "progress", i+1, "/", len(tables))
+
+		// Create handler for this table
+		handler := NewSnapshotHandler(s.sinkerMgr, table.Name)
+
+		// Run snapshot for this table
+		startLSN, err := s.querier.Run(ctx, table.Schema, table.Name, handler)
+		if err != nil {
+			s.mu.Lock()
+			s.progress.State = "failed"
+			s.progress.Error = fmt.Sprintf("table %s: %v", s.progress.CurrentTable, err)
+			s.mu.Unlock()
+			slog.Error("snapshot: table failed", "table", s.progress.CurrentTable, "error", err)
+			return
+		}
+
+		// Calculate next LSN for CDC to resume from
+		nextLSN, err := s.querier.IncrementLSN(ctx, startLSN)
+		if err != nil {
+			s.mu.Lock()
+			s.progress.State = "failed"
+			s.progress.Error = fmt.Sprintf("increment LSN for %s: %v", s.progress.CurrentTable, err)
+			s.mu.Unlock()
+			return
+		}
+
+		// Update offset store
+		fullTableName := fmt.Sprintf("%s.%s", table.Schema, table.Name)
+		startLSNStr := hex.EncodeToString(startLSN)
+		nextLSNStr := hex.EncodeToString(nextLSN)
+
+		if err := s.offsetStore.Set(fullTableName, startLSNStr, nextLSNStr); err != nil {
+			s.mu.Lock()
+			s.progress.State = "failed"
+			s.progress.Error = fmt.Sprintf("set offset for %s: %v", fullTableName, err)
+			s.mu.Unlock()
+			return
+		}
+
+		if err := s.offsetStore.Flush(); err != nil {
+			s.mu.Lock()
+			s.progress.State = "failed"
+			s.progress.Error = fmt.Sprintf("flush offset: %v", err)
+			s.mu.Unlock()
+			return
+		}
+
+		// Update progress
+		s.mu.Lock()
+		s.progress.Processed = i + 1
+		s.progress.CurrentRows = 0
+		s.progress.CurrentTotal = 0
+		s.mu.Unlock()
+
+		slog.Info("snapshot: table completed", "table", fullTableName, "start_lsn", startLSNStr, "next_lsn", nextLSNStr)
+	}
+
+	// Mark as completed
+	s.mu.Lock()
+	s.progress.State = "completed"
+	s.progress.CompletedAt = time.Now().Format(time.RFC3339)
+	s.mu.Unlock()
+
+	slog.Info("snapshot: all tables completed")
+}
+
+// clearSinkTables truncates all sink tables for the given CDC tables.
+func (s *SnapshotService) clearSinkTables(ctx context.Context, tables []CDCTable) error {
+	slog.Info("snapshot: clearing sink tables")
+
+	// Get all sink names from sinker manager
+	sinkNames := s.sinkerMgr.ListDatabases()
+	if len(sinkNames) == 0 {
+		slog.Warn("snapshot: no sinks configured, skipping clear")
+		return nil
+	}
+
+	// For each sink, truncate all tables
+	for _, sinkName := range sinkNames {
+		sinker, err := s.sinkerMgr.GetSinker(sinkName)
+		if err != nil {
+			slog.Warn("snapshot: failed to get sinker", "sink", sinkName, "error", err)
+			continue
+		}
+
+		// Get tables in this sink
+		sinkTables, err := s.sinkerMgr.QueryTables(sinkName)
+		if err != nil {
+			slog.Warn("snapshot: failed to query tables", "sink", sinkName, "error", err)
+			continue
+		}
+
+		// Truncate each table
+		for _, tableName := range sinkTables {
+			// Build full table name (without schema, just table name)
+			// Sink tables are typically created with just the original table name
+			query := fmt.Sprintf("DELETE FROM %s", tableName)
+			if err := sinker.ExecContext(ctx, query); err != nil {
+				slog.Warn("snapshot: failed to clear table", "sink", sinkName, "table", tableName, "error", err)
+				// Continue with other tables
+			} else {
+				slog.Info("snapshot: cleared table", "sink", sinkName, "table", tableName)
+			}
+		}
+	}
+
+	return nil
+}
+
+// SnapshotHandler handles snapshot batches by writing to sink.
+type SnapshotHandler struct {
+	sinkerMgr *sinker.Manager
+	tableName string
+}
+
+// NewSnapshotHandler creates a new SnapshotHandler.
+func NewSnapshotHandler(sinkerMgr *sinker.Manager, tableName string) *SnapshotHandler {
+	return &SnapshotHandler{
+		sinkerMgr: sinkerMgr,
+		tableName: tableName,
+	}
+}
+
+// HandleBatch processes a batch of changes from snapshot.
+func (h *SnapshotHandler) HandleBatch(ctx context.Context, changes []core.Change) error {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	sinkNames := h.sinkerMgr.ListDatabases()
+	if len(sinkNames) == 0 {
+		return fmt.Errorf("no sinks configured")
+	}
+
+	// Group changes by sink (in practice, we write to all sinks)
+	for _, sinkName := range sinkNames {
+		sinker, err := h.sinkerMgr.GetSinker(sinkName)
+		if err != nil {
+			return fmt.Errorf("get sinker %s: %w", sinkName, err)
+		}
+
+		// Convert changes to sink ops
+		// First pass: determine columns from first change
+		firstChange := changes[0]
+		columns := make([]string, 0, len(firstChange.Data))
+		for col := range firstChange.Data {
+			columns = append(columns, col)
+		}
+
+		// Build rows
+		rows := make([][]interface{}, 0, len(changes))
+		for _, change := range changes {
+			row := make([]interface{}, 0, len(change.Data))
+			for _, col := range columns {
+				if val, ok := change.Data[col]; ok {
+					row = append(row, val)
+				} else {
+					row = append(row, nil)
+				}
+			}
+			rows = append(rows, row)
+		}
+
+		dataSet := &core.DataSet{
+			Columns: columns,
+			Rows:    rows,
+		}
+
+		op := core.Sink{
+			OpType:  core.OpInsert,
+			Config:  core.SinkConfig{Output: h.tableName},
+			DataSet: dataSet,
+		}
+		ops := []core.Sink{op}
+
+		// Write to sink
+		if err := sinker.Write(ctx, ops); err != nil {
+			return fmt.Errorf("write to sink %s: %w", sinkName, err)
+		}
+	}
+
+	return nil
+}
+
+// CDCTable represents a CDC-enabled table.
+type CDCTable struct {
+	Schema string
+	Name   string
+}
+
+// GetCDCTables returns the list of CDC-enabled tables from config.
+func GetCDCTables(cfg *config.Config) []CDCTable {
+	tables := make([]CDCTable, 0, len(cfg.Tables))
+	for _, t := range cfg.Tables {
+		parts := strings.SplitN(t, ".", 2)
+		if len(parts) == 2 {
+			tables = append(tables, CDCTable{
+				Schema: parts[0],
+				Name:   parts[1],
+			})
+		}
+	}
+	return tables
+}


### PR DESCRIPTION
Fixes: #199

## What Changed

Added a new Snapshot dashboard page with progress tracking and integrated it with the existing snapshot service.

### Key Changes:
- **Sidebar**: Added "Snapshot" navigation item at the same level as "Monitor"
- **API Endpoints**:
  - `POST /api/snapshot/start` - Trigger snapshot for all CDC-enabled tables
  - `GET /api/snapshot/status` - Return current progress (polling endpoint)
  - `GET /api/snapshot/tables` - Return list of CDC-enabled tables
- **SnapshotService**: New service with singleton pattern that stops Poller, clears sink tables, runs snapshot, then auto-restarts Poller
- **Dashboard Page**: Shows table list preview when idle, progress bar with per-table details when running, and result message when completed/failed
- **State Machine**: Uses `StateSnapshot` to pause Poller during snapshot operations

### Progress Tracking
The dashboard displays:
- Overall progress: completed tables / total tables
- Per-table progress: processed rows / total rows
- Current table name being processed

## Why It Changed

Users need a UI to trigger and monitor snapshot operations. The project already has the snapshot service infrastructure but lacked a user-facing dashboard to leverage it.

## How to Test

1. Navigate to the new "Snapshot" item in the sidebar
2. Verify the page displays the list of CDC-enabled tables
3. Click "Start Snapshot" and monitor the progress bar and per-table details
4. Verify the Poller is stopped during snapshot (check `StateSnapshot` state)
5. After completion, verify LSN is written to offset and Poller auto-restarts
6. Refresh the page during an active snapshot to confirm progress loads immediately
7. Attempt to start a second snapshot while one is running (should be blocked by singleton)

## Summary by Sourcery

Add a backend snapshot service and API plus UI navigation entry to trigger and monitor database snapshot operations from the dashboard.

New Features:
- Expose snapshot REST endpoints to start a snapshot, query its status, and list CDC-enabled tables.
- Introduce a SnapshotService with singleton behavior to orchestrate CDC table snapshots, manage progress state, and update offsets.
- Add a Snapshot sidebar entry in the dashboard layout to access the new snapshot page.

Enhancements:
- Extend the sinker abstraction and SQLite implementation with a generic ExecContext helper to support table maintenance operations used by snapshots.