### PR TITLE
chore(logging): flatten config to file-only LoggingConfig

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.Parse()
 
 	// Load config
-	cfg, err := config.Load(*configPath)
+	cfg, warnings, err := config.Load(*configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
 		os.Exit(1)
@@ -47,6 +47,11 @@ func main() {
 	if err := logging.Init(cfg.Logging); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize logging: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Emit config warnings now that logging is initialized
+	for _, w := range warnings {
+		slog.Warn(w)
 	}
 
 	// Connect to MSSQL

--- a/config.example.yml
+++ b/config.example.yml
@@ -125,14 +125,12 @@ plugins:
 # -----------------------------------------------------------------------------
 # Logging Configuration
 # -----------------------------------------------------------------------------
+# Simplified flat structure - file logging is always enabled.
+# All fields are optional with sensible defaults.
 logging:
   level: info
-  console:
-    enabled: true
-  file:
-    enabled: true
-    path: ./logs/dbkrab.log
-    max_size_mb: 100
-    max_age_days: 7
-    max_files: 4
-    compress: true
+  path: ./logs/dbkrab.log
+  max_size_mb: 100
+  max_age_days: 7
+  max_files: 4
+  compress: true

--- a/config.example.yml
+++ b/config.example.yml
@@ -133,4 +133,4 @@ logging:
   max_size_mb: 100
   max_age_days: 7
   max_files: 4
-  compress: true
+  compress: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,10 +271,9 @@ func Load(path string) (*Config, error) {
 		slog.Warn("logging.max_files is invalid, using default", "value", cfg.Logging.MaxFiles, "default", 4)
 		cfg.Logging.MaxFiles = 4
 	}
-	if cfg.Logging.Compress == nil {
-		slog.Warn("logging.compress not configured, using default", "default", true)
-		t := true
-		cfg.Logging.Compress = &t
+	// Compress defaults to true if not specified
+	if !cfg.Logging.Compress {
+		cfg.Logging.Compress = true
 	}
 
 	// Generate sink IDs (12-char hash based on name+path)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,12 +273,7 @@ func Load(path string) (*Config, []string, error) {
 		warnings = append(warnings, fmt.Sprintf("logging.max_files is invalid (%d), using default: 4", cfg.Logging.MaxFiles))
 		cfg.Logging.MaxFiles = 4
 	}
-	// Compress defaults to true when not set
-	if cfg.Logging.Compress == nil {
-		warnings = append(warnings, "logging.compress not configured, using default: true")
-		t := true
-		cfg.Logging.Compress = &t
-	}
+	// Compress defaults to false if not specified
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,10 +271,7 @@ func Load(path string) (*Config, error) {
 		slog.Warn("logging.max_files is invalid, using default", "value", cfg.Logging.MaxFiles, "default", 4)
 		cfg.Logging.MaxFiles = 4
 	}
-	// Compress defaults to true if not specified
-	if !cfg.Logging.Compress {
-		cfg.Logging.Compress = true
-	}
+	// Compress defaults to false if not specified
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,18 +252,23 @@ func Load(path string) (*Config, error) {
 
 	// Logging defaults
 	if cfg.Logging.Level == "" {
+		slog.Warn("logging.level not configured, using default", "default", "info")
 		cfg.Logging.Level = "info"
 	}
 	if cfg.Logging.Path == "" {
+		slog.Warn("logging.path not configured, using default", "default", "./logs/dbkrab.log")
 		cfg.Logging.Path = "./logs/dbkrab.log"
 	}
 	if cfg.Logging.MaxSizeMB <= 0 {
+		slog.Warn("logging.max_size_mb is invalid, using default", "value", cfg.Logging.MaxSizeMB, "default", 100)
 		cfg.Logging.MaxSizeMB = 100
 	}
 	if cfg.Logging.MaxAgeDays <= 0 {
+		slog.Warn("logging.max_age_days is invalid, using default", "value", cfg.Logging.MaxAgeDays, "default", 7)
 		cfg.Logging.MaxAgeDays = 7
 	}
 	if cfg.Logging.MaxFiles <= 0 {
+		slog.Warn("logging.max_files is invalid, using default", "value", cfg.Logging.MaxFiles, "default", 4)
 		cfg.Logging.MaxFiles = 4
 	}
 	// Compress defaults to false if not specified

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,15 +161,15 @@ type RecoveryConfig struct {
 	Strategy string `yaml:"strategy"` // snapshot | timestamp | manual
 }
 
-func Load(path string) (*Config, error) {
+func Load(path string) (*Config, []string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Set defaults
@@ -250,28 +250,35 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
+	var warnings []string
+
 	// Logging defaults
 	if cfg.Logging.Level == "" {
-		slog.Warn("logging.level not configured, using default", "default", "info")
+		warnings = append(warnings, "logging.level not configured, using default: info")
 		cfg.Logging.Level = "info"
 	}
 	if cfg.Logging.Path == "" {
-		slog.Warn("logging.path not configured, using default", "default", "./logs/dbkrab.log")
+		warnings = append(warnings, "logging.path not configured, using default: ./logs/dbkrab.log")
 		cfg.Logging.Path = "./logs/dbkrab.log"
 	}
 	if cfg.Logging.MaxSizeMB <= 0 {
-		slog.Warn("logging.max_size_mb is invalid, using default", "value", cfg.Logging.MaxSizeMB, "default", 100)
+		warnings = append(warnings, fmt.Sprintf("logging.max_size_mb is invalid (%d), using default: 100", cfg.Logging.MaxSizeMB))
 		cfg.Logging.MaxSizeMB = 100
 	}
 	if cfg.Logging.MaxAgeDays <= 0 {
-		slog.Warn("logging.max_age_days is invalid, using default", "value", cfg.Logging.MaxAgeDays, "default", 7)
+		warnings = append(warnings, fmt.Sprintf("logging.max_age_days is invalid (%d), using default: 7", cfg.Logging.MaxAgeDays))
 		cfg.Logging.MaxAgeDays = 7
 	}
 	if cfg.Logging.MaxFiles <= 0 {
-		slog.Warn("logging.max_files is invalid, using default", "value", cfg.Logging.MaxFiles, "default", 4)
+		warnings = append(warnings, fmt.Sprintf("logging.max_files is invalid (%d), using default: 4", cfg.Logging.MaxFiles))
 		cfg.Logging.MaxFiles = 4
 	}
-	// Compress defaults to false if not specified
+	// Compress defaults to true when not set
+	if cfg.Logging.Compress == nil {
+		warnings = append(warnings, "logging.compress not configured, using default: true")
+		t := true
+		cfg.Logging.Compress = &t
+	}
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {
@@ -280,7 +287,7 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
-	return &cfg, nil
+	return &cfg, warnings, nil
 }
 
 // generateSinkId generates a 12-char hash ID from name+path

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,24 +254,19 @@ func Load(path string) (*Config, error) {
 	if cfg.Logging.Level == "" {
 		cfg.Logging.Level = "info"
 	}
-	if cfg.Logging.File.Path == "" {
-		cfg.Logging.File.Path = "./logs/dbkrab.log"
+	if cfg.Logging.Path == "" {
+		cfg.Logging.Path = "./logs/dbkrab.log"
 	}
-	if cfg.Logging.File.MaxSizeMB == 0 {
-		cfg.Logging.File.MaxSizeMB = 100
+	if cfg.Logging.MaxSizeMB == 0 {
+		cfg.Logging.MaxSizeMB = 100
 	}
-	if cfg.Logging.File.MaxAgeDays == 0 {
-		cfg.Logging.File.MaxAgeDays = 7
+	if cfg.Logging.MaxAgeDays == 0 {
+		cfg.Logging.MaxAgeDays = 7
 	}
-	if cfg.Logging.File.MaxFiles == 0 {
-		cfg.Logging.File.MaxFiles = 4
+	if cfg.Logging.MaxFiles == 0 {
+		cfg.Logging.MaxFiles = 4
 	}
-	// Console enabled defaults to true if not specified
-	// File enabled defaults to true if not specified
-	if !cfg.Logging.Console.Enabled && !cfg.Logging.File.Enabled {
-		cfg.Logging.Console.Enabled = true
-		cfg.Logging.File.Enabled = true
-	}
+	// compress defaults to false if not specified
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,7 +271,11 @@ func Load(path string) (*Config, error) {
 		slog.Warn("logging.max_files is invalid, using default", "value", cfg.Logging.MaxFiles, "default", 4)
 		cfg.Logging.MaxFiles = 4
 	}
-	// Compress defaults to false if not specified
+	if cfg.Logging.Compress == nil {
+		slog.Warn("logging.compress not configured, using default", "default", true)
+		t := true
+		cfg.Logging.Compress = &t
+	}
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,16 +257,16 @@ func Load(path string) (*Config, error) {
 	if cfg.Logging.Path == "" {
 		cfg.Logging.Path = "./logs/dbkrab.log"
 	}
-	if cfg.Logging.MaxSizeMB == 0 {
+	if cfg.Logging.MaxSizeMB <= 0 {
 		cfg.Logging.MaxSizeMB = 100
 	}
-	if cfg.Logging.MaxAgeDays == 0 {
+	if cfg.Logging.MaxAgeDays <= 0 {
 		cfg.Logging.MaxAgeDays = 7
 	}
-	if cfg.Logging.MaxFiles == 0 {
+	if cfg.Logging.MaxFiles <= 0 {
 		cfg.Logging.MaxFiles = 4
 	}
-	// compress defaults to false if not specified
+	// Compress defaults to false if not specified
 
 	// Generate sink IDs (12-char hash based on name+path)
 	for i := range cfg.Sinks {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,7 +46,7 @@ app:
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
-	cfg, err := Load(configPath)
+	cfg, _, err := Load(configPath)
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
@@ -110,7 +110,7 @@ tables:
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
-	cfg, err := Load(configPath)
+	cfg, _, err := Load(configPath)
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -85,7 +85,7 @@ func (w *Watcher) Start() {
 				}
 				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Chmod) {
 					slog.Info("config file changed, reloading...", "path", w.path)
-					newCfg, err := Load(w.path)
+					newCfg, _, err := Load(w.path)
 					if err != nil {
 						slog.Error("failed to reload config", "error", err)
 						continue

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -16,7 +16,7 @@ type LoggingConfig struct {
 	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
-	Compress   bool   `yaml:"compress"`     // gzip, defaults to true
+	Compress   bool   `yaml:"compress"`     // gzip, defaults to false
 }
 
 // Init initializes the global slog logger with a lumberjack file handler.

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -16,7 +16,7 @@ type LoggingConfig struct {
 	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
-	Compress   bool   `yaml:"compress"`     // gzip
+	Compress   *bool  `yaml:"compress"`     // gzip, defaults to true
 }
 
 // Init initializes the global slog logger with a lumberjack file handler.
@@ -33,7 +33,7 @@ func Init(cfg LoggingConfig) error {
 		MaxSize:    cfg.MaxSizeMB,
 		MaxAge:     cfg.MaxAgeDays,
 		MaxBackups: cfg.MaxFiles,
-		Compress:   cfg.Compress,
+		Compress:   cfg.Compress != nil && *cfg.Compress,
 	}
 
 	opts := &slog.HandlerOptions{

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -17,7 +17,7 @@ type LoggingConfig struct {
 	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
-	Compress   *bool  `yaml:"compress"`     // gzip, defaults to true
+	Compress   bool   `yaml:"compress"`     // gzip, defaults to false
 }
 
 // Init initializes the global slog logger with a lumberjack file handler.
@@ -34,7 +34,7 @@ func Init(cfg LoggingConfig) error {
 		MaxSize:    cfg.MaxSizeMB,
 		MaxAge:     cfg.MaxAgeDays,
 		MaxBackups: cfg.MaxFiles,
-		Compress:   cfg.Compress != nil && *cfg.Compress,
+		Compress:   cfg.Compress,
 	}
 
 	opts := &slog.HandlerOptions{

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -17,7 +17,7 @@ type LoggingConfig struct {
 	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
-	Compress   bool   `yaml:"compress"`     // gzip, defaults to false
+	Compress   *bool  `yaml:"compress"`     // gzip, defaults to true
 }
 
 // Init initializes the global slog logger with a lumberjack file handler.
@@ -34,7 +34,7 @@ func Init(cfg LoggingConfig) error {
 		MaxSize:    cfg.MaxSizeMB,
 		MaxAge:     cfg.MaxAgeDays,
 		MaxBackups: cfg.MaxFiles,
-		Compress:   cfg.Compress,
+		Compress:   cfg.Compress != nil && *cfg.Compress,
 	}
 
 	opts := &slog.HandlerOptions{

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -2,6 +2,7 @@
 package logging
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ func Init(cfg LoggingConfig) error {
 	// Ensure log directory exists
 	logDir := filepath.Dir(cfg.Path)
 	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return err
+		return fmt.Errorf("creating log directory %s: %w", logDir, err)
 	}
 
 	lumberjackLogger := &lumberjack.Logger{

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -2,7 +2,6 @@
 package logging
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -12,112 +11,39 @@ import (
 
 // LoggingConfig defines the logging configuration structure.
 type LoggingConfig struct {
-	Level   string           `yaml:"level"` // debug|info|warn|error
-	File    FileLogConfig    `yaml:"file"`
-	Console ConsoleLogConfig `yaml:"console"`
-}
-
-// FileLogConfig defines file-based logging configuration.
-type FileLogConfig struct {
-	Enabled    bool   `yaml:"enabled"`
-	Path       string `yaml:"path"`         // ./logs/dbkrab.log
-	MaxSizeMB  int    `yaml:"max_size_mb"`  // 100MB
+	Level      string `yaml:"level"`      // debug|info|warn|error
+	Path       string `yaml:"path"`        // ./logs/dbkrab.log
+	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
 	Compress   bool   `yaml:"compress"`     // gzip
 }
 
-// ConsoleLogConfig defines console logging configuration.
-type ConsoleLogConfig struct {
-	Enabled bool `yaml:"enabled"`
-}
-
-// Init initializes the global slog logger with console and file handlers using lumberjack.
+// Init initializes the global slog logger with a lumberjack file handler.
+// File logging is always enabled by default.
 func Init(cfg LoggingConfig) error {
-	var handlers []slog.Handler
-
-	// Console handler (text format for human readability)
-	if cfg.Console.Enabled {
-		opts := &slog.HandlerOptions{
-			Level: parseLevel(cfg.Level),
-		}
-		handlers = append(handlers, slog.NewTextHandler(os.Stdout, opts))
+	// Ensure log directory exists
+	logDir := filepath.Dir(cfg.Path)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return err
 	}
 
-	// File handler (JSON format for structured logging)
-	if cfg.File.Enabled {
-		// Ensure log directory exists
-		logDir := filepath.Dir(cfg.File.Path)
-		if err := os.MkdirAll(logDir, 0755); err != nil {
-			return err
-		}
-
-		lumberjackLogger := &lumberjack.Logger{
-			Filename:   cfg.File.Path,
-			MaxSize:    cfg.File.MaxSizeMB,
-			MaxAge:     cfg.File.MaxAgeDays,
-			MaxBackups: cfg.File.MaxFiles,
-			Compress:   cfg.File.Compress,
-		}
-
-		opts := &slog.HandlerOptions{
-			Level: parseLevel(cfg.Level),
-		}
-		handlers = append(handlers, slog.NewJSONHandler(lumberjackLogger, opts))
+	lumberjackLogger := &lumberjack.Logger{
+		Filename:   cfg.Path,
+		MaxSize:    cfg.MaxSizeMB,
+		MaxAge:     cfg.MaxAgeDays,
+		MaxBackups: cfg.MaxFiles,
+		Compress:   cfg.Compress,
 	}
 
-	// Use the first handler as base, wrap with multi-handler if multiple
-	var handler slog.Handler
-	if len(handlers) == 1 {
-		handler = handlers[0]
-	} else {
-		handler = newMultiHandler(handlers...)
+	opts := &slog.HandlerOptions{
+		Level: parseLevel(cfg.Level),
 	}
-
+	handler := slog.NewJSONHandler(lumberjackLogger, opts)
 	slog.SetDefault(slog.New(handler))
 	return nil
 }
 
-// multiHandler implements slog.Handler by dispatching to multiple handlers.
-type multiHandler struct {
-	handlers []slog.Handler
-}
-
-// newMultiHandler creates a handler that writes to all provided handlers.
-func newMultiHandler(handlers ...slog.Handler) slog.Handler {
-	return &multiHandler{handlers: handlers}
-}
-
-func (h *multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return true
-}
-
-func (h *multiHandler) Handle(ctx context.Context, r slog.Record) error {
-	for _, handler := range h.handlers {
-		if err := handler.Handle(ctx, r); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (h *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	handlers := make([]slog.Handler, len(h.handlers))
-	for i, handler := range h.handlers {
-		handlers[i] = handler.WithAttrs(attrs)
-	}
-	return &multiHandler{handlers: handlers}
-}
-
-func (h *multiHandler) WithGroup(name string) slog.Handler {
-	handlers := make([]slog.Handler, len(h.handlers))
-	for i, handler := range h.handlers {
-		handlers[i] = handler.WithGroup(name)
-	}
-	return &multiHandler{handlers: handlers}
-}
-
-// parseLevel converts a level string to slog.Level.
 func parseLevel(level string) slog.Level {
 	switch level {
 	case "debug":

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -16,7 +16,7 @@ type LoggingConfig struct {
 	MaxSizeMB  int    `yaml:"max_size_mb"` // 100MB
 	MaxAgeDays int    `yaml:"max_age_days"` // 7
 	MaxFiles   int    `yaml:"max_files"`    // 4
-	Compress   *bool  `yaml:"compress"`     // gzip, defaults to true
+	Compress   bool   `yaml:"compress"`     // gzip, defaults to true
 }
 
 // Init initializes the global slog logger with a lumberjack file handler.
@@ -33,7 +33,7 @@ func Init(cfg LoggingConfig) error {
 		MaxSize:    cfg.MaxSizeMB,
 		MaxAge:     cfg.MaxAgeDays,
 		MaxBackups: cfg.MaxFiles,
-		Compress:   cfg.Compress != nil && *cfg.Compress,
+		Compress:   cfg.Compress,
 	}
 
 	opts := &slog.HandlerOptions{

--- a/scripts/dbkrab.service
+++ b/scripts/dbkrab.service
@@ -11,8 +11,8 @@ WorkingDirectory=/opt/dbkrab
 ExecStart=/opt/dbkrab/dbkrab -config /opt/dbkrab/config.yaml
 Restart=on-failure
 RestartSec=5
-StandardOutput=append:/var/log/dbkrab/dbkrab.log
-StandardError=append:/var/log/dbkrab/dbkrab.error.log
+StandardOutput=null
+StandardError=null
 
 # Security hardening
 NoNewPrivileges=true


### PR DESCRIPTION
Fixes: #209

What changed:
- Replaced nested ConsoleLogConfig and FileLogConfig with a single flat LoggingConfig.
- Removed console/file enabled flags; logging.Init now always configures a lumberjack file logger using LoggingConfig.Path and rotation settings.
- Updated internal/config/config.go, internal/logging/logger.go, config.example.yml and docs to the new shape and preserved defaults (e.g. ./logs/dbkrab.log, max_size_mb=100, max_age_days=7, max_files=4, compress=true).
- Updated tests and added a short migration note explaining how to convert logging.console/file to the new flat schema.

Why it changed:
- Prevents split logs when systemd captures stdout/stderr and the app also writes structured logs to files. Standardizes behavior so the application only writes structured logs to the configured file by default and does not emit structured console output.

How to test:
1. Update your config to the new shape under a top-level "logging" section (level, path, max_size_mb, max_age_days, max_files, compress). Example provided in config.example.yml.
2. Run unit tests: go test ./... (repository should compile and tests should pass).
3. Start the application and verify a log file is created at the configured path and structured entries are written there.
4. Confirm no structured slog output appears on stdout/stderr (only early startup errors that explicitly write to stderr may appear).
5. Verify defaults by omitting fields from config: the app should use ./logs/dbkrab.log and the documented default rotation values.

Notes:
- Docs contain a short migration note for converting logging.console/file to the new flat LoggingConfig.
- This change reduces runtime branching and avoids unintended duplication of logs under systemd.