### PR TITLE
fix: make reset use systemd to manage dbkrab process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,11 @@ stop:
 ## restart: Restart dbkrab
 restart: stop deploy
 
-## reset: Reset dbkrab state (clear DB and logs under /opt/dbkrab) and restart
+## reset: Reset dbkrab state (clear DB and logs under /opt/dbkrab) and restart via systemd
 reset:
 	@echo "Resetting dbkrab state..."
 	@echo "Stopping dbkrab..."
-	@pkill -x dbkrab 2>/dev/null || true
+	@sudo systemctl stop dbkrab 2>/dev/null || pkill -9 -f /opt/dbkrab/dbkrab 2>/dev/null || true
 	@sleep 2
 	@echo "Deleting app data files..."
 	@rm -rf /opt/dbkrab/data/app/*
@@ -154,11 +154,11 @@ reset:
 	@echo "Deleting logs..."
 	@rm -rf /opt/dbkrab/logs/*
 	@mkdir -p /opt/dbkrab/logs
-	@echo "Starting dbkrab..."
-	@cd /opt/dbkrab && nohup ./dbkrab --config config.yaml > logs/dbkrab.log 2>&1 &
+	@echo "Starting dbkrab via systemd..."
+	@sudo systemctl start dbkrab
 	@sleep 3
-	@if pgrep -x dbkrab >/dev/null; then \
-		echo "✅ dbkrab restarted"; \
+	@if systemctl is-active --quiet dbkrab; then \
+		echo "✅ dbkrab restarted via systemd"; \
 	else \
 		echo "❌ dbkrab failed to start"; \
 	fi


### PR DESCRIPTION
## 改动说明

将 Resetting dbkrab state...
Stopping dbkrab...
Deleting app data files...
Deleting sinks data files...
Deleting logs...
Starting dbkrab via systemd...
✅ dbkrab restarted via systemd 命令改为通过 systemd 管理 dbkrab 进程，与 Deploying to /opt/dbkrab...
🦀 Deploying dbkrab...
📁 Creating directories...
🔨 Building...
make[1]: Entering directory '/home/dayi/code/dbkrab'
Building dbkrab...
go build  -ldflags "-X main.Version=74566c0 -X main.BuildTime=2026-04-23_12:26:58" -o bin/dbkrab ./cmd/app
Built: bin/dbkrab
make[1]: Leaving directory '/home/dayi/code/dbkrab'
🛑 Stopping old process...
   Stopping systemd service...
   Waiting for process to exit...
📦 Installing binary...
⚙️  Installing config...
   Config already exists at /opt/dbkrab/config.yaml, keeping existing config
🚀 Starting dbkrab...
   Starting via systemd...
✅ Deployment successful!
   Dashboard: http://localhost:9021 保持一致。

## 改动内容

- 停止服务：改用 ，fallback 到 
- 启动服务：改用 
- 状态检查：改用 

## 相关文件

- Makefile