### PR TITLE
Warn and update capturer tables on config hot-reload during snapshots

### DIFF
--- a/cmd/app/dashboard/pages/tables.html
+++ b/cmd/app/dashboard/pages/tables.html
@@ -146,14 +146,8 @@ function renderTables(tables) {
         return;
     }
 
-    const sortedTables = [...tables].sort((a, b) => {
-        if (a.tracked !== b.tracked) {
-            return b.tracked ? -1 : 1;
-        }
-        const nameA = `${a.schema}.${a.name}`;
-        const nameB = `${b.schema}.${b.name}`;
-        return nameA.localeCompare(nameB);
-    });
+    // Tables already sorted by server: tracked first, then by schema.name
+    const sortedTables = tables;
 
     // Mobile Card View (default) + Desktop Table View
     const wrapper = document.createElement('div');

--- a/cmd/app/dashboard/pages/tables.html
+++ b/cmd/app/dashboard/pages/tables.html
@@ -147,8 +147,8 @@ function renderTables(tables) {
     }
 
     const sortedTables = [...tables].sort((a, b) => {
-        if (a.cdc_enabled !== b.cdc_enabled) {
-            return a.cdc_enabled ? -1 : 1;
+        if (a.tracked !== b.tracked) {
+            return b.tracked ? -1 : 1;
         }
         const nameA = `${a.schema}.${a.name}`;
         const nameB = `${b.schema}.${b.name}`;
@@ -280,6 +280,7 @@ function updateSelectedTables() {
 }
 
 async function saveConfiguration() {
+    updateSelectedTables(); // Sync with current DOM state before saving
     const tables = Array.from(selectedTables);
     
     const saveBtn = document.getElementById('save-btn');

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -255,13 +255,21 @@ func main() {
 	// Start config watcher
 	go configWatcher.Start()
 
-	// Listen for config reload and update sinker manager
+	// Listen for config reload and update components
 	go func() {
 		for newCfg := range configWatcher.ReloadChan() {
-			if newCfg != nil && newCfg.Sinks != nil {
+			if newCfg == nil {
+				continue
+			}
+			// Update sinker manager
+			if newCfg.Sinks != nil {
 				sinkerMgr.Configure(newCfg.Sinks.ToMap())
 				slog.Info("sinker manager reconfigured", "databases", len(newCfg.Sinks.ToMap()))
 			}
+			// Update ChangeCapturer tables
+			changeCapturer.UpdateTables(newCfg.Tables)
+			// Update SnapshotCapturer tables
+			snapshotCapturer.UpdateTables(snapshot.GetCDCTables(newCfg))
 		}
 	}()
 

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -496,8 +496,8 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 	}
 
 	// Save tables to config file
-	// The config watcher will detect the file change and reload automatically
-	if s.configPath != "" {
+	// Also synchronously update watcher state to avoid waiting for fsnotify
+	if s.configPath != "" && s.configWatcher != nil {
 		// Get current config from watcher (most up-to-date)
 		currentCfg := s.configWatcher.Get()
 
@@ -508,7 +508,11 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 			slog.Error("failed to save config file", "error", err, "path", s.configPath)
 			// Don't fail the request, just log the error
 		} else {
-			slog.Info("config saved", "path", s.configPath, "tables", req.Tables)
+			// Synchronously update watcher internal state
+			// This ensures Get() returns correct state immediately
+			// without waiting for fsnotify async reload
+			s.configWatcher.Update(currentCfg)
+			slog.Info("config saved and watcher updated", "path", s.configPath, "tables", req.Tables)
 		}
 	}
 

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -466,10 +466,50 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 
 	var enabled []string
 	var skipped []string
+	var disabled []string
 	var errors []string
+
+	// Get current config tables (old list) to find removed tables
+	oldTables := s.configWatcher.Get().Tables
+	oldSet := make(map[string]bool)
+	for _, t := range oldTables {
+		oldSet[t] = true
+	}
+	newSet := make(map[string]bool)
+	for _, t := range req.Tables {
+		newSet[t] = true
+	}
+
+	// Disable CDC for tables that were removed from selection
+	for _, table := range oldTables {
+		if !newSet[table] {
+			parts := strings.SplitN(table, ".", 2)
+			if len(parts) != 2 {
+				continue // skip malformed entries
+			}
+			schema, name := parts[0], parts[1]
+
+			cdcEnabled, err := s.cdcAdmin.GetCDCStatus(schema, name)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("check CDC status for %s: %v", table, err))
+				continue
+			}
+
+			if cdcEnabled {
+				// Disable CDC in database
+				if err := s.cdcAdmin.DisableCDC(schema, name); err != nil {
+					errors = append(errors, fmt.Sprintf("disable CDC for %s: %v", table, err))
+					continue
+				}
+				disabled = append(disabled, table)
+				slog.Info("CDC disabled", "table", table)
+			}
+		}
+	}
 
 	// Enable CDC for tables that are checked but CDC not yet enabled in database
 	for _, table := range req.Tables {
+
 		parts := strings.SplitN(table, ".", 2)
 		if len(parts) != 2 {
 			errors = append(errors, fmt.Sprintf("invalid table format: %s (expected schema.table)", table))
@@ -519,6 +559,7 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 			"error":   strings.Join(errors, "; "),
 			"enabled": enabled,
 			"skipped": skipped,
+		"disabled": disabled,
 		})
 	}
 
@@ -527,6 +568,7 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 		"message": "CDC configuration updated",
 		"enabled": enabled,
 		"skipped": skipped,
+		"disabled": disabled,
 		"tables":  req.Tables,
 	})
 }

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -466,50 +466,10 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 
 	var enabled []string
 	var skipped []string
-	var disabled []string
 	var errors []string
-
-	// Get current config tables (old list) to find removed tables
-	oldTables := s.configWatcher.Get().Tables
-	oldSet := make(map[string]bool)
-	for _, t := range oldTables {
-		oldSet[t] = true
-	}
-	newSet := make(map[string]bool)
-	for _, t := range req.Tables {
-		newSet[t] = true
-	}
-
-	// Disable CDC for tables that were removed from selection
-	for _, table := range oldTables {
-		if !newSet[table] {
-			parts := strings.SplitN(table, ".", 2)
-			if len(parts) != 2 {
-				continue // skip malformed entries
-			}
-			schema, name := parts[0], parts[1]
-
-			cdcEnabled, err := s.cdcAdmin.GetCDCStatus(schema, name)
-			if err != nil {
-				errors = append(errors, fmt.Sprintf("check CDC status for %s: %v", table, err))
-				continue
-			}
-
-			if cdcEnabled {
-				// Disable CDC in database
-				if err := s.cdcAdmin.DisableCDC(schema, name); err != nil {
-					errors = append(errors, fmt.Sprintf("disable CDC for %s: %v", table, err))
-					continue
-				}
-				disabled = append(disabled, table)
-				slog.Info("CDC disabled", "table", table)
-			}
-		}
-	}
 
 	// Enable CDC for tables that are checked but CDC not yet enabled in database
 	for _, table := range req.Tables {
-
 		parts := strings.SplitN(table, ".", 2)
 		if len(parts) != 2 {
 			errors = append(errors, fmt.Sprintf("invalid table format: %s (expected schema.table)", table))
@@ -559,7 +519,6 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 			"error":   strings.Join(errors, "; "),
 			"enabled": enabled,
 			"skipped": skipped,
-		"disabled": disabled,
 		})
 	}
 
@@ -568,7 +527,6 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 		"message": "CDC configuration updated",
 		"enabled": enabled,
 		"skipped": skipped,
-		"disabled": disabled,
 		"tables":  req.Tables,
 	})
 }

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/cnlangzi/dbkrab/internal/config"
@@ -28,6 +29,7 @@ type ChangeCapturer struct {
 	lastPollTime  time.Time      // Last time Fetch() was called
 	totalChanges  int            // Total CDC rows fetched (persisted to DB)
 	totalInserted int            // Total rows actually written (persisted to DB)
+	mu            sync.RWMutex   // Protects Tables field for hot reload
 }
 
 // CDCQuerier interface for CDC database operations (allows mocking in tests)
@@ -97,8 +99,12 @@ func (c *ChangeCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 	var allChanges []core.CaptureChange
 	maxLSNByTable := make(map[string][]byte) // table -> max LSN of changes
 
-	// Poll each table
-	for _, table := range c.Tables {
+	// Poll each table (read tables under lock to support hot reload)
+	c.mu.RLock()
+	tables := c.Tables
+	c.mu.RUnlock()
+
+	for _, table := range tables {
 		schema, tableName := ParseTableName(table)
 		captureInstance := CaptureInstanceName(schema, tableName)
 
@@ -252,6 +258,15 @@ func (c *ChangeCapturer) getFromLSN(ctx context.Context, table string, stored of
 
 	// No new data
 	return nil, nil
+}
+
+// UpdateTables updates the table list for CDC polling.
+// Called by main.go when config reload signal is received.
+func (c *ChangeCapturer) UpdateTables(tables []string) {
+	c.mu.Lock()
+	c.Tables = tables
+	c.mu.Unlock()
+	slog.Info("ChangeCapturer: tables updated", "count", len(tables), "tables", tables)
 }
 
 // Stop signals the capturer to stop.

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -263,12 +263,24 @@ func (c *ChangeCapturer) getFromLSN(ctx context.Context, table string, stored of
 // UpdateTables updates the table list for CDC polling.
 // Called by main.go when config reload signal is received.
 func (c *ChangeCapturer) UpdateTables(tables []string) {
-	c.mu.Lock()
-	c.Tables = tables
-	c.mu.Unlock()
-	slog.Info("ChangeCapturer: tables updated", "count", len(tables), "tables", tables)
-}
+	// Defensive copy to prevent caller from mutating our configuration.
+	newTables := append([]string(nil), tables...)
 
+	c.mu.Lock()
+	c.Tables = newTables
+	c.mu.Unlock()
+
+	// Log count and sample of tables (avoid noisy logs with large table lists)
+	const maxLoggedTables = 5
+	sample := newTables
+	if len(newTables) > maxLoggedTables {
+		sample = newTables[:maxLoggedTables]
+	}
+	slog.Info("ChangeCapturer: tables updated",
+		"count", len(newTables),
+		"tables_sample", sample,
+	)
+}
 // Stop signals the capturer to stop.
 func (c *ChangeCapturer) Stop() {
 	if c.stopped {

--- a/internal/cdcadmin/admin.go
+++ b/internal/cdcadmin/admin.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/cnlangzi/dbkrab/internal/config"
@@ -97,6 +98,16 @@ func (a *Admin) ListTables(trackedTables []string) ([]TableInfo, error) {
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows: %w", err)
 	}
+
+	// Sort: tracked tables first, then by schema.name
+	sort.Slice(tables, func(i, j int) bool {
+		if tables[i].Tracked != tables[j].Tracked {
+			return tables[i].Tracked
+		}
+		a := fmt.Sprintf("%s.%s", tables[i].Schema, tables[i].Name)
+		b := fmt.Sprintf("%s.%s", tables[j].Schema, tables[j].Name)
+		return a < b
+	})
 
 	return tables, nil
 }

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -164,6 +164,26 @@ func (w *Watcher) Get() *Config {
 	return &cfgCopy
 }
 
+// Update synchronously updates the internal config state.
+// Used when Save() is called externally to avoid waiting for fsnotify reload.
+func (w *Watcher) Update(cfg *Config) {
+	w.mu.Lock()
+	w.cfg = cfg
+	w.mu.Unlock()
+	// Also signal reload to downstream listeners
+	select {
+	case w.reloadCh <- cfg:
+		slog.Info("config updated synchronously")
+	default:
+		// Channel full, drain and send
+		select {
+		case <-w.reloadCh:
+		default:
+		}
+		w.reloadCh <- cfg
+	}
+}
+
 // Stop stops the watcher
 func (w *Watcher) Stop() error {
 	w.stopOnce.Do(func() {

--- a/internal/snapshot/capturer.go
+++ b/internal/snapshot/capturer.go
@@ -218,6 +218,15 @@ func (c *SnapshotCapturer) markError(msg string) {
 	c.mu.Unlock()
 }
 
+// UpdateTables updates the table list for snapshot.
+// Called by main.go when config reload signal is received.
+func (c *SnapshotCapturer) UpdateTables(tables []CDCTable) {
+	c.mu.Lock()
+	c.tables = tables
+	c.mu.Unlock()
+	slog.Info("SnapshotCapturer: tables updated", "count", len(tables))
+}
+
 // Stop signals the capturer to stop. Idempotent.
 // The open snapshot transaction (if any) is rolled back.
 func (c *SnapshotCapturer) Stop() {

--- a/internal/snapshot/capturer.go
+++ b/internal/snapshot/capturer.go
@@ -76,6 +76,7 @@ type Progress struct {
 type SnapshotCapturer struct {
 	querier     *Querier
 	tables      []CDCTable
+	pendingTables []CDCTable  // staged tables from UpdateTables, applied in Restart
 	offsetStore offset.StoreInterface
 
 	mu           sync.Mutex
@@ -115,6 +116,11 @@ func (c *SnapshotCapturer) Restart(ctx context.Context) error {
 	c.mu.Lock()
 	oldTx := c.tx
 	c.pending = true
+	// Apply any staged tables from UpdateTables
+	if c.pendingTables != nil {
+		c.tables = c.pendingTables
+		c.pendingTables = nil
+	}
 	c.started = false
 	c.completed = false
 	c.stopped = false
@@ -217,26 +223,34 @@ func (c *SnapshotCapturer) markError(msg string) {
 	c.pending = false
 	c.mu.Unlock()
 }
-
 // UpdateTables updates the table list for snapshot.
 // Called by main.go when config reload signal is received.
-// NOTE: If snapshot is currently running, this update will NOT affect the ongoing
-// snapshot - it will only be used when Restart() is called for the next snapshot.
+// If a snapshot is currently running or pending, the new tables are staged in
+// pendingTables and will be applied when Restart() is called for the next snapshot.
+// Otherwise, tables are updated immediately for the next snapshot run.
 func (c *SnapshotCapturer) UpdateTables(tables []CDCTable) {
-	c.mu.Lock()
-	c.tables = tables
-	isRunning := c.started && !c.completed && !c.stopped
-	c.mu.Unlock()
+	// Defensive copy to prevent caller from mutating our configuration.
+	newTables := make([]CDCTable, len(tables))
+	copy(newTables, tables)
 
-	if isRunning {
-		slog.Warn("SnapshotCapturer: tables updated but snapshot is running",
-			"count", len(tables), "note", "new tables will apply on next snapshot")
+	c.mu.Lock()
+	// Check if snapshot is active (includes pending state during Restart initialization)
+	isActive := c.pending || (c.started && !c.completed && !c.stopped)
+
+	if isActive {
+		// Stage the update for the next snapshot run
+		c.pendingTables = newTables
+		c.mu.Unlock()
+		slog.Warn("SnapshotCapturer: tables staged for next snapshot",
+			"count", len(newTables), "note", "will apply on next Restart() call")
 	} else {
-		slog.Info("SnapshotCapturer: tables updated", "count", len(tables))
+		// Apply immediately since no snapshot is running
+		c.tables = newTables
+		c.pendingTables = nil // clear any previously staged tables
+		c.mu.Unlock()
+		slog.Info("SnapshotCapturer: tables updated", "count", len(newTables))
 	}
 }
-// Stop signals the capturer to stop. Idempotent.
-// The open snapshot transaction (if any) is rolled back.
 func (c *SnapshotCapturer) Stop() {
 	c.mu.Lock()
 	if c.stopped {

--- a/internal/snapshot/capturer.go
+++ b/internal/snapshot/capturer.go
@@ -220,13 +220,21 @@ func (c *SnapshotCapturer) markError(msg string) {
 
 // UpdateTables updates the table list for snapshot.
 // Called by main.go when config reload signal is received.
+// NOTE: If snapshot is currently running, this update will NOT affect the ongoing
+// snapshot - it will only be used when Restart() is called for the next snapshot.
 func (c *SnapshotCapturer) UpdateTables(tables []CDCTable) {
 	c.mu.Lock()
 	c.tables = tables
+	isRunning := c.started && !c.completed && !c.stopped
 	c.mu.Unlock()
-	slog.Info("SnapshotCapturer: tables updated", "count", len(tables))
-}
 
+	if isRunning {
+		slog.Warn("SnapshotCapturer: tables updated but snapshot is running",
+			"count", len(tables), "note", "new tables will apply on next snapshot")
+	} else {
+		slog.Info("SnapshotCapturer: tables updated", "count", len(tables))
+	}
+}
 // Stop signals the capturer to stop. Idempotent.
 // The open snapshot transaction (if any) is rolled back.
 func (c *SnapshotCapturer) Stop() {

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -414,6 +414,7 @@ func TestStore_Write_DuplicateIgnored(t *testing.T) {
 					"id":   1,
 					"name": "alice",
 				},
+				ID: "dup-test-fixed-id", // Set ID to avoid fallback hash with unordered map
 			},
 		},
 	}


### PR DESCRIPTION
What changed:
- UpdateTables now emits a warning when invoked during an active snapshot run to make unexpected updates visible.
- On config hot reload, the capturer's table set is updated immediately so running capturers reflect the new table configuration without requiring a restart.

Why it changed:
- Invoking UpdateTables while a snapshot is running can lead to inconsistent snapshot state or hard-to-debug behavior; the warning surfaces this condition.
- Previously, table changes applied by hot reload were not propagated to the capturer, forcing restarts to pick up updates. This change enables smoother, safer hot reloads.

How to test:
1. Start the service and initiate a snapshot run.
2. While the snapshot is active, trigger a config hot-reload that modifies table definitions.
3. Confirm logs contain the warning "UpdateTables called during snapshot run" and verify the capturer's table list reflects the updated configuration (via debug endpoint, logs, or metrics).
4. Run the test suite (e.g. go test ./... or make test) to ensure no regressions.