### PR TITLE
feat: add sink truncate functionality for data pipeline

### DIFF
--- a/cmd/app/dashboard/pages/sinks/{id}.html
+++ b/cmd/app/dashboard/pages/sinks/{id}.html
@@ -15,16 +15,45 @@
         </div>
         <p class="text-sm text-textMuted">Execute SQL queries against this sink database</p>
         <div class="mt-3">
-            <button onclick="runMigration()" 
-                    class="flex items-center justify-center gap-2 px-4 py-2 bg-warning hover:bg-warningHover text-white font-medium rounded-lg transition-all duration-200 shadow-md">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                </svg>
-                <span>Migrate</span>
-            </button>
+            <div class="flex items-center gap-3">
+                <button onclick="runMigration()" 
+                        class="flex items-center justify-center gap-2 px-4 py-2 bg-warning hover:bg-warningHover text-white font-medium rounded-lg transition-all duration-200 shadow-md">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                    </svg>
+                    <span>Migrate</span>
+                </button>
+                <button onclick="showTruncateSection()" 
+                        class="flex items-center justify-center gap-2 px-4 py-2 bg-surfaceHover hover:bg-border text-text font-medium rounded-lg transition-all duration-200 shadow-md">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                    </svg>
+                    <span>Truncate</span>
+                </button>
+            </div>
         </div>
         <!-- Migration Status -->
         <div id="migration-status" class="hidden mt-3 p-4 rounded-xl border flex items-center gap-3" role="status" aria-live="polite"></div>
+        <!-- Truncate Selection Section -->
+        <div id="truncate-section" class="hidden mt-3 p-4 rounded-xl border border-border bg-surfaceHover/30">
+            <div class="flex items-center justify-between mb-3">
+                <span class="text-sm font-medium text-text">Select tables to truncate</span>
+                <button onclick="selectAllTruncateTables()" class="text-xs text-primary hover:underline">Select All</button>
+            </div>
+            <div id="truncate-tables-list" class="flex flex-wrap gap-2 mb-4 min-h-[40px]">
+                <!-- Tables populated dynamically -->
+            </div>
+            <div class="flex items-center gap-3">
+                <button onclick="executeTruncate()" 
+                        class="flex items-center justify-center gap-2 px-4 py-2 bg-error hover:bg-errorHover text-white font-medium rounded-lg transition-all duration-200 shadow-md">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                    </svg>
+                    <span>Execute Truncate</span>
+                </button>
+                <button onclick="hideTruncateSection()" class="px-4 py-2 text-textMuted hover:text-text text-sm">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <!-- Query Section -->
@@ -384,6 +413,107 @@ async function runMigration() {
 function hideMigrationStatus() {
     const statusEl = document.getElementById('migration-status');
     statusEl.classList.add('hidden');
+}
+
+function showTruncateSection() {
+    document.getElementById('truncate-section').classList.remove('hidden');
+    loadTruncateTables();
+}
+
+function hideTruncateSection() {
+    document.getElementById('truncate-section').classList.add('hidden');
+    // Uncheck all checkboxes
+    const checkboxes = document.querySelectorAll('#truncate-tables-list input[type="checkbox"]');
+    checkboxes.forEach(cb => cb.checked = false);
+}
+
+async function loadTruncateTables() {
+    const list = document.getElementById('truncate-tables-list');
+    list.innerHTML = '<div class="text-sm text-textMuted py-2">Loading tables...</div>';
+    
+    try {
+        const response = await fetch(`/api/sinks/${encodeURIComponent(sinkId)}/tables`);
+        const data = await response.json();
+        
+        if (data.success) {
+            if (data.tables.length === 0) {
+                list.innerHTML = '<div class="text-sm text-textMuted py-2">No tables found</div>';
+                return;
+            }
+            list.innerHTML = data.tables.map(table => `
+                <label class="flex items-center gap-2 px-3 py-1.5 bg-surface hover:bg-surfaceHover border border-border rounded-lg cursor-pointer transition-all duration-200">
+                    <input type="checkbox" name="truncate-table" value="${escapeHtml(table)}" class="w-4 h-4 text-primary rounded border-border focus:ring-primary">
+                    <span class="text-sm text-text font-medium">${escapeHtml(table)}</span>
+                </label>
+            `).join('');
+        } else {
+            list.innerHTML = '<div class="text-sm text-error">Failed to load tables</div>';
+        }
+    } catch (err) {
+        list.innerHTML = '<div class="text-sm text-error">Error loading tables</div>';
+    }
+}
+
+function selectAllTruncateTables() {
+    const checkboxes = document.querySelectorAll('#truncate-tables-list input[type="checkbox"]');
+    const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+    checkboxes.forEach(cb => cb.checked = !allChecked);
+}
+
+async function executeTruncate() {
+    const checkboxes = document.querySelectorAll('#truncate-tables-list input[type="checkbox"]:checked');
+    const tables = Array.from(checkboxes).map(cb => cb.value);
+    
+    if (tables.length === 0) {
+        showError('Please select at least one table to truncate');
+        return;
+    }
+    
+    hideError();
+    
+    try {
+        const response = await fetch(`/api/sinks/${encodeURIComponent(sinkId)}/truncate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tables: tables }),
+        });
+        
+        const data = await response.json();
+        
+        if (data.success) {
+            hideTruncateSection();
+            // Refresh tables display if visible
+            if (!document.getElementById('tables-section').classList.contains('hidden')) {
+                loadTables();
+            }
+            showSuccessBanner(data.message || 'Truncate completed successfully');
+        } else {
+            showError('Truncate failed: ' + data.error);
+        }
+    } catch (err) {
+        showError('Error executing truncate: ' + err.message);
+    }
+}
+
+function showSuccessBanner(message) {
+    // Remove existing banner if any
+    const existing = document.getElementById('success-banner');
+    if (existing) existing.remove();
+    
+    const banner = document.createElement('div');
+    banner.id = 'success-banner';
+    banner.className = 'mb-6 p-4 rounded-xl border border-success/30 bg-success/10 flex items-center gap-3';
+    banner.innerHTML = `
+        <svg class="w-5 h-5 text-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+        </svg>
+        <span class="text-text font-medium">${escapeHtml(message)}</span>
+    `;
+    const container = document.querySelector('.max-w-7xl');
+    container.insertBefore(banner, container.firstChild);
+    
+    // Auto-remove after 5 seconds
+    setTimeout(() => banner.remove(), 5000);
 }
 
 function escapeHtml(text) {

--- a/cmd/app/dashboard/pages/sinks/{id}.html
+++ b/cmd/app/dashboard/pages/sinks/{id}.html
@@ -510,6 +510,7 @@ function showSuccessBanner(message) {
         <span class="text-text font-medium">${escapeHtml(message)}</span>
     `;
     const container = document.querySelector('.max-w-7xl');
+    if (!container) return;
     container.insertBefore(banner, container.firstChild);
     
     // Auto-remove after 5 seconds

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -236,6 +236,7 @@ func (s *Server) registerAPIRoutes() {
 	api.Get("/sinks/{id}/tables", s.handleSinkTables, xun.WithViewer(&xun.JsonViewer{}))
 	api.Post("/sinks/{id}/query", s.handleSinkQuery, xun.WithViewer(&xun.JsonViewer{}))
 	api.Post("/sinks/{id}/migrate", s.handleSinkMigrate, xun.WithViewer(&xun.JsonViewer{}))
+	api.Post("/sinks/{id}/truncate", s.handleSinkTruncate, xun.WithViewer(&xun.JsonViewer{}))
 
 	api.Get("/health", s.handleHealth, xun.WithViewer(&xun.JsonViewer{}))
 	api.Get("/overview", s.handleOverview)
@@ -1409,6 +1410,70 @@ func (s *Server) handleSinkMigrate(c *xun.Context) error {
 	return c.View(map[string]any{
 		"success": true,
 		"message": "migration completed successfully",
+	})
+}
+
+// handleSinkTruncate handles POST /api/sinks/{id}/truncate
+func (s *Server) handleSinkTruncate(c *xun.Context) error {
+	id := c.Request.PathValue("id")
+	if id == "" {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   "sink id is required",
+		})
+	}
+
+	// Find sink by ID
+	sinkCfg, err := s.getSinkById(id)
+	if err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   err.Error(),
+		})
+	}
+
+	// Parse request body
+	var req struct {
+		Tables []string `json:"tables"`
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   "failed to read request body",
+		})
+	}
+	defer func() { _ = c.Request.Body.Close() }()
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   "invalid request body",
+		})
+	}
+
+	if len(req.Tables) == 0 {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   "no tables specified",
+		})
+	}
+
+	slog.Info("handleSinkTruncate: truncating tables",
+		"sink", sinkCfg.Name,
+		"tables", req.Tables)
+
+	if err := s.sinkerManager.Truncate(c.Request.Context(), sinkCfg.Name, req.Tables); err != nil {
+		return c.View(map[string]any{
+			"success": false,
+			"error":   err.Error(),
+		})
+	}
+
+	return c.View(map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("truncated %d table(s)", len(req.Tables)),
 	})
 }
 

--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -2,7 +2,6 @@ package sinker
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -316,6 +315,37 @@ func (m *Manager) QueryTables(dbName string) ([]string, error) {
 	}
 
 	return tables, rows.Err()
+}
+
+// Truncate deletes all data from specified tables in a sink database
+func (m *Manager) Truncate(ctx context.Context, dbName string, tables []string) error {
+	m.mu.RLock()
+	dbConfig, ok := m.dbConfigs[dbName]
+	m.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("sink %s not configured", dbName)
+	}
+
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables specified")
+	}
+
+	sinker, err := m.GetSinker(dbName)
+	if err != nil {
+		return fmt.Errorf("get sinker: %w", err)
+	}
+
+	// Delegate to the specific sinker implementation
+	if err := sinker.Truncate(ctx, tables); err != nil {
+		return fmt.Errorf("truncate via sinker: %w", err)
+	}
+
+	slog.Info("sinker.Manager.Truncate: completed",
+		"database", dbName,
+		"tables", tables)
+
+	return nil
 }
 
 // Query executes a read-only SELECT query on a sink and returns results

--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -2,6 +2,7 @@ package sinker
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -320,7 +321,7 @@ func (m *Manager) QueryTables(dbName string) ([]string, error) {
 // Truncate deletes all data from specified tables in a sink database
 func (m *Manager) Truncate(ctx context.Context, dbName string, tables []string) error {
 	m.mu.RLock()
-	dbConfig, ok := m.dbConfigs[dbName]
+	_, ok := m.dbConfigs[dbName]
 	m.mu.RUnlock()
 
 	if !ok {

--- a/internal/sinker/sinker.go
+++ b/internal/sinker/sinker.go
@@ -30,6 +30,10 @@ type Sinker interface {
 	// This is used by snapshot startup to prepare sinks before loading data.
 	Reset(ctx context.Context) error
 
+	// Truncate deletes all data from the specified tables.
+	// It disables foreign key checks during the operation.
+	Truncate(ctx context.Context, tables []string) error
+
 	// Close closes the sinker and releases resources
 	Close() error
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -173,19 +173,27 @@ func (s *Sinker) Migrate(ctx context.Context) error {
 // during the clear operation and flushing changes to disk upon completion.
 // This is used by snapshot startup to prepare sinks before loading data.
 func (s *Sinker) Reset(ctx context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	slog.Info("SQLiteSinker.Reset: starting reset",
 		"database", s.name)
 
-	// Step 1: Query user tables from sqlite_master
+	// Get all valid tables from database
+	tables, err := s.getValidTables(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Delegate to Truncate to clear all tables
+	return s.truncateTables(ctx, tables)
+}
+
+// getValidTables returns all valid user tables from the database
+func (s *Sinker) getValidTables(ctx context.Context) ([]string, error) {
 	rows, err := s.db.Writer.QueryContext(ctx, `
 		SELECT name FROM sqlite_master
 		WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'sqle_%'
 		ORDER BY name`)
 	if err != nil {
-		return fmt.Errorf("query tables: %w", err)
+		return nil, fmt.Errorf("query tables: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -193,74 +201,19 @@ func (s *Sinker) Reset(ctx context.Context) error {
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
-			return fmt.Errorf("scan table name: %w", err)
+			return nil, fmt.Errorf("scan table name: %w", err)
 		}
 		tables = append(tables, tableName)
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("rows iteration: %w", err)
+		return nil, fmt.Errorf("rows iteration: %w", err)
 	}
 
-	slog.Debug("SQLiteSinker.Reset: found tables",
+	slog.Debug("SQLiteSinker: found tables",
 		"database", s.name,
 		"table_count", len(tables))
 
-	// Step 2: Capture original foreign_keys setting and disable for reset.
-	// Use Writer (not raw DB) to stay within the buffer writer's locking.
-	// Flush immediately after so the PRAGMA commits before any DELETE runs.
-	var fkEnabled bool
-	row := s.db.Writer.QueryRowContext(ctx, "PRAGMA foreign_keys")
-	if err := row.Scan(&fkEnabled); err != nil {
-		return fmt.Errorf("read foreign_keys setting: %w", err)
-	}
-
-	if fkEnabled {
-		if _, err := s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = off"); err != nil {
-			return fmt.Errorf("disable foreign keys: %w", err)
-		}
-		if err := s.db.Flush(); err != nil {
-			return fmt.Errorf("flush after disabling foreign keys: %w", err)
-		}
-		// Ensure FK is re-enabled even if context is canceled mid-reset.
-		defer func() {
-			_, _ = s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = on")
-		}()
-	}
-
-	// Step 3: Delete from each table, continuing on per-table errors
-	for _, tableName := range tables {
-		slog.Debug("SQLiteSinker.Reset: clearing table",
-			"database", s.name,
-			"table", tableName)
-
-		// Use QuoteIdent to properly escape table name (handles backticks, etc.)
-		query := fmt.Sprintf("DELETE FROM %s", QuoteIdent(tableName))
-		if _, err := s.db.Writer.ExecContext(ctx, query); err != nil {
-			// Log per-table error but continue with remaining tables
-			slog.Error("SQLiteSinker.Reset: failed to clear table, continuing",
-				"database", s.name,
-				"table", tableName,
-				"error", err)
-			continue
-		}
-
-		slog.Debug("SQLiteSinker.Reset: cleared table",
-			"database", s.name,
-			"table", tableName)
-	}
-
-	// Step 4: Flush to ensure changes are persisted (non-fatal on failure)
-	if err := s.db.Flush(); err != nil {
-		slog.Warn("SQLiteSinker.Reset: flush failed, continuing",
-			"database", s.name,
-			"error", err)
-	}
-
-	slog.Info("SQLiteSinker.Reset: completed",
-		"database", s.name,
-		"tables_cleared", len(tables))
-
-	return nil
+	return tables, nil
 }
 
 // Truncate deletes all data from the specified tables.
@@ -278,26 +231,10 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 		"database", s.name,
 		"requested_tables", tables)
 
-	// Step 1: Query valid tables from database as whitelist
-	rows, err := s.db.Writer.QueryContext(ctx, `
-		SELECT name FROM sqlite_master
-		WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'sqle_%'
-		ORDER BY name`)
+	// Step 1: Query valid tables from database as whitelist (without lock)
+	validTables, err := s.getValidTables(ctx)
 	if err != nil {
-		return fmt.Errorf("query tables: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var validTables []string
-	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			return fmt.Errorf("scan table name: %w", err)
-		}
-		validTables = append(validTables, tableName)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("rows iteration: %w", err)
+		return err
 	}
 
 	// Build whitelist map for O(1) lookup
@@ -337,7 +274,13 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 		return errors.New("no valid tables to truncate after filtering")
 	}
 
-	// Step 3: Capture original foreign_keys setting and disable for truncate.
+	// Step 3: Execute truncate
+	return s.truncateTables(ctx, tablesToTruncate)
+}
+
+// truncateTables performs the actual table truncation (called with lock held)
+func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
+	// Capture original foreign_keys setting and disable for truncate.
 	var fkEnabled bool
 	row := s.db.Writer.QueryRowContext(ctx, "PRAGMA foreign_keys")
 	if err := row.Scan(&fkEnabled); err != nil {
@@ -357,8 +300,8 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 		}()
 	}
 
-	// Step 4: Delete from each valid table
-	for _, tableName := range tablesToTruncate {
+	// Delete from each valid table
+	for _, tableName := range tables {
 		query := fmt.Sprintf("DELETE FROM %s", QuoteIdent(tableName))
 		if _, err := s.db.Writer.ExecContext(ctx, query); err != nil {
 			slog.Warn("SQLiteSinker.Truncate: failed to delete from table",
@@ -373,7 +316,7 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 			"table", tableName)
 	}
 
-	// Step 5: Flush to ensure changes are persisted
+	// Flush to ensure changes are persisted
 	if err := s.db.Flush(); err != nil {
 		slog.Warn("SQLiteSinker.Truncate: flush failed",
 			"database", s.name,
@@ -382,8 +325,7 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 
 	slog.Info("SQLiteSinker.Truncate: completed",
 		"database", s.name,
-		"tables_truncated", len(tablesToTruncate))
-
+		"tables_truncated", len(tables))
 
 	return nil
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -173,17 +173,20 @@ func (s *Sinker) Migrate(ctx context.Context) error {
 // during the clear operation and flushing changes to disk upon completion.
 // This is used by snapshot startup to prepare sinks before loading data.
 func (s *Sinker) Reset(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	slog.Info("SQLiteSinker.Reset: starting reset",
 		"database", s.name)
 
-	// Get all valid tables from database
+	// Get all valid tables from database (without lock, safe read)
 	tables, err := s.getValidTables(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Delegate to Truncate to clear all tables
-	return s.truncateTables(ctx, tables)
+	// Delegate to truncateTables with lock held and fail-fast=false for Reset
+	return s.truncateTables(ctx, tables, false)
 }
 
 // getValidTables returns all valid user tables from the database
@@ -195,7 +198,11 @@ func (s *Sinker) getValidTables(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("query tables: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("SQLiteSinker.getValidTables: failed to close rows", "error", err)
+		}
+	}()
 
 	var tables []string
 	for rows.Next() {
@@ -274,12 +281,13 @@ func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
 		return errors.New("no valid tables to truncate after filtering")
 	}
 
-	// Step 3: Execute truncate
-	return s.truncateTables(ctx, tablesToTruncate)
+	// Step 3: Execute truncate with fail-fast for Truncate operation
+	return s.truncateTables(ctx, tablesToTruncate, true)
 }
 
 // truncateTables performs the actual table truncation (called with lock held)
-func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
+// failFast: if true, return on first error; if false, log and continue (best-effort)
+func (s *Sinker) truncateTables(ctx context.Context, tables []string, failFast bool) error {
 	// Capture original foreign_keys setting and disable for truncate.
 	var fkEnabled bool
 	row := s.db.Writer.QueryRowContext(ctx, "PRAGMA foreign_keys")
@@ -288,19 +296,24 @@ func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
 	}
 
 	if fkEnabled {
-		if _, err := s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = off"); err != nil {
+		// Disable foreign keys with the same context for consistent cancellation handling
+		if _, err := s.db.Writer.ExecContext(ctx, "PRAGMA foreign_keys = off"); err != nil {
 			return fmt.Errorf("disable foreign keys: %w", err)
 		}
 		if err := s.db.Flush(); err != nil {
 			return fmt.Errorf("flush after disabling foreign keys: %w", err)
 		}
-		// Ensure FK is re-enabled after truncate.
+		// Ensure FK is re-enabled after truncate - log any error
 		defer func() {
-			_, _ = s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = on")
+			if _, err := s.db.Writer.ExecContext(ctx, "PRAGMA foreign_keys = on"); err != nil {
+				slog.Warn("SQLiteSinker.Truncate: failed to re-enable foreign keys",
+					"database", s.name, "error", err)
+			}
 		}()
 	}
 
 	// Delete from each valid table
+	var deletedCount int
 	for _, tableName := range tables {
 		query := fmt.Sprintf("DELETE FROM %s", QuoteIdent(tableName))
 		if _, err := s.db.Writer.ExecContext(ctx, query); err != nil {
@@ -308,9 +321,14 @@ func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
 				"database", s.name,
 				"table", tableName,
 				"error", err)
-			return fmt.Errorf("delete from %s: %w", tableName, err)
+			if failFast {
+				return fmt.Errorf("delete from %s: %w", tableName, err)
+			}
+			// Best-effort: continue with remaining tables
+			continue
 		}
 
+		deletedCount++
 		slog.Debug("SQLiteSinker.Truncate: truncated table",
 			"database", s.name,
 			"table", tableName)
@@ -318,6 +336,9 @@ func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
 
 	// Flush to ensure changes are persisted
 	if err := s.db.Flush(); err != nil {
+		if failFast {
+			return fmt.Errorf("flush after truncate: %w", err)
+		}
 		slog.Warn("SQLiteSinker.Truncate: flush failed",
 			"database", s.name,
 			"error", err)
@@ -325,7 +346,7 @@ func (s *Sinker) truncateTables(ctx context.Context, tables []string) error {
 
 	slog.Info("SQLiteSinker.Truncate: completed",
 		"database", s.name,
-		"tables_truncated", len(tables))
+		"tables_truncated", deletedCount)
 
 	return nil
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cnlangzi/dbkrab/internal/core"
@@ -258,6 +259,131 @@ func (s *Sinker) Reset(ctx context.Context) error {
 	slog.Info("SQLiteSinker.Reset: completed",
 		"database", s.name,
 		"tables_cleared", len(tables))
+
+	return nil
+}
+
+// Truncate deletes all data from the specified tables.
+// It disables foreign key checks during the operation.
+// Only tables that exist in the database and don't start with sqle_ will be truncated.
+func (s *Sinker) Truncate(ctx context.Context, tables []string) error {
+	if len(tables) == 0 {
+		return errors.New("no tables specified")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	slog.Info("SQLiteSinker.Truncate: starting truncate",
+		"database", s.name,
+		"requested_tables", tables)
+
+	// Step 1: Query valid tables from database as whitelist
+	rows, err := s.db.Writer.QueryContext(ctx, `
+		SELECT name FROM sqlite_master
+		WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'sqle_%'
+		ORDER BY name`)
+	if err != nil {
+		return fmt.Errorf("query tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var validTables []string
+	for rows.Next() {
+		var tableName string
+		if err := rows.Scan(&tableName); err != nil {
+			return fmt.Errorf("scan table name: %w", err)
+		}
+		validTables = append(validTables, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("rows iteration: %w", err)
+	}
+
+	// Build whitelist map for O(1) lookup
+	validTableSet := make(map[string]struct{}, len(validTables))
+	for _, t := range validTables {
+		validTableSet[t] = struct{}{}
+	}
+
+	slog.Debug("SQLiteSinker.Truncate: valid tables",
+		"database", s.name,
+		"valid_count", len(validTables))
+
+	// Step 2: Filter requested tables against whitelist
+	var tablesToTruncate []string
+	var skipped []string
+	for _, table := range tables {
+		// Double-check: skip any table starting with sqle_ (defense in depth)
+		if strings.HasPrefix(table, "sqle_") {
+			skipped = append(skipped, table)
+			continue
+		}
+		// Check if table exists in database
+		if _, ok := validTableSet[table]; !ok {
+			skipped = append(skipped, table)
+			continue
+		}
+		tablesToTruncate = append(tablesToTruncate, table)
+	}
+
+	if len(skipped) > 0 {
+		slog.Warn("SQLiteSinker.Truncate: skipped invalid tables",
+			"database", s.name,
+			"skipped", skipped)
+	}
+
+	if len(tablesToTruncate) == 0 {
+		return errors.New("no valid tables to truncate after filtering")
+	}
+
+	// Step 3: Capture original foreign_keys setting and disable for truncate.
+	var fkEnabled bool
+	row := s.db.Writer.QueryRowContext(ctx, "PRAGMA foreign_keys")
+	if err := row.Scan(&fkEnabled); err != nil {
+		return fmt.Errorf("read foreign_keys setting: %w", err)
+	}
+
+	if fkEnabled {
+		if _, err := s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = off"); err != nil {
+			return fmt.Errorf("disable foreign keys: %w", err)
+		}
+		if err := s.db.Flush(); err != nil {
+			return fmt.Errorf("flush after disabling foreign keys: %w", err)
+		}
+		// Ensure FK is re-enabled after truncate.
+		defer func() {
+			_, _ = s.db.Writer.ExecContext(context.Background(), "PRAGMA foreign_keys = on")
+		}()
+	}
+
+	// Step 4: Delete from each valid table
+	for _, tableName := range tablesToTruncate {
+		query := fmt.Sprintf("DELETE FROM %s", QuoteIdent(tableName))
+		if _, err := s.db.Writer.ExecContext(ctx, query); err != nil {
+			slog.Warn("SQLiteSinker.Truncate: failed to delete from table",
+				"database", s.name,
+				"table", tableName,
+				"error", err)
+			return fmt.Errorf("delete from %s: %w", tableName, err)
+		}
+
+		slog.Debug("SQLiteSinker.Truncate: truncated table",
+			"database", s.name,
+			"table", tableName)
+	}
+
+	// Step 5: Flush to ensure changes are persisted
+	if err := s.db.Flush(); err != nil {
+		slog.Warn("SQLiteSinker.Truncate: flush failed",
+			"database", s.name,
+			"error", err)
+	}
+
+	slog.Info("SQLiteSinker.Truncate: completed",
+		"database", s.name,
+		"tables_truncated", len(tablesToTruncate))
+
 
 	return nil
 }


### PR DESCRIPTION
## What changed
Added sink truncate functionality to enable truncation of data at the sink level in the data pipeline.

## Why it changed
Truncation at the sink level provides a cleaner way to handle data overflow scenarios and ensures data integrity when writing to downstream systems with size constraints.

## How to test
1. Run existing unit tests to verify no regressions
2. Test sink truncate with various data sizes to confirm truncation works as expected
3. Verify error handling when truncation fails