### PR TITLE
fix: use Sinker's Reader for QueryTables/Query instead of temporary connections

### DIFF
--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -289,8 +289,10 @@ func (m *Manager) QueryTables(dbName string) ([]string, error) {
 		path = fmt.Sprintf("./data/sinks/%s.db", dbName)
 	}
 
-	// Open read-only connection
-	db, err := sql.Open("sqlite3", path+"?mode=ro")
+	// Open read-only connection with busy_timeout to handle WAL lock contention
+	// When main process is writing to WAL, we need to wait for the lock
+	dsn := fmt.Sprintf("%s?mode=ro&_busy_timeout=5000", path)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -337,8 +339,10 @@ func (m *Manager) Query(dbName, query string) ([]string, []map[string]any, error
 		path = fmt.Sprintf("./data/sinks/%s.db", dbName)
 	}
 
-	// Open read-only connection
-	db, err := sql.Open("sqlite3", path+"?mode=ro")
+	// Open read-only connection with busy_timeout to handle WAL lock contention
+	// When main process is writing to WAL, we need to wait for the lock
+	dsn := fmt.Sprintf("%s?mode=ro&_busy_timeout=5000", path)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open database: %w", err)
 	}

--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -322,20 +321,11 @@ func (m *Manager) Query(dbName, query string) ([]string, []map[string]any, error
 	}
 
 	// Execute query via sinker (limit 1000 for safety)
-	results, err := skr.Query(query, 1000)
+	// Returns columns in SQLite table order
+	columns, results, err := skr.Query(query, 1000)
 	if err != nil {
 		return nil, nil, fmt.Errorf("query: %w", err)
 	}
-
-	// Get columns from first result and sort for stable ordering
-	if len(results) == 0 {
-		return []string{}, []map[string]any{}, nil
-	}
-	columns := make([]string, 0, len(results[0]))
-	for col := range results[0] {
-		columns = append(columns, col)
-	}
-	sort.Strings(columns)  // Stable column order for UI display
 
 	// Handle datetime conversion for API response
 	for _, row := range results {

--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -2,9 +2,9 @@ package sinker
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -13,7 +13,6 @@ import (
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/monitor"
 	sinkSqlite "github.com/cnlangzi/dbkrab/internal/sinker/sqlite"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 // Manager manages Sinkers and routes sink operations to appropriate sinkers.
@@ -270,161 +269,65 @@ func (m *Manager) GetSinkConfig(dbName string) (config.SinkConfig, bool) {
 	return cfg, ok
 }
 
-// QueryTables returns the list of tables in a sink database
+// QueryTables returns the list of tables in a sink database.
+// Uses the Sinker's existing Reader connection instead of creating a temporary one.
 func (m *Manager) QueryTables(dbName string) ([]string, error) {
-	m.mu.RLock()
-	dbConfig, ok := m.dbConfigs[dbName]
-	m.mu.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("sink %s not configured", dbName)
-	}
-
-	if dbConfig.Type != "sqlite" {
-		return nil, fmt.Errorf("QueryTables only supported for sqlite sinks")
-	}
-
-	path := dbConfig.DSN
-	if path == "" {
-		path = fmt.Sprintf("./data/sinks/%s.db", dbName)
-	}
-
-	// Open read-only connection with busy_timeout to handle WAL lock contention
-	// When main process is writing to WAL, we need to wait for the lock
-	dsn := fmt.Sprintf("%s?mode=ro&_busy_timeout=5000", path)
-	db, err := sql.Open("sqlite3", dsn)
+	// Get existing sinker to reuse its Reader connection
+	skr, err := m.GetSinker(dbName)
 	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	// Query tables from sqlite_master
-	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
-	if err != nil {
-		return nil, fmt.Errorf("query tables: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var tables []string
-	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			continue
-		}
-		// Skip internal SQLite tables
-		if !strings.HasPrefix(tableName, "sqlite_") {
-			tables = append(tables, tableName)
-		}
+		return nil, fmt.Errorf("get sinker %s: %w", dbName, err)
 	}
 
-	return tables, rows.Err()
+	return skr.QueryTables()
 }
 
-// Query executes a read-only SELECT query on a sink and returns results
+// Query executes a read-only SELECT query on a sink and returns results.
+// Uses the Sinker's existing Reader connection instead of creating a temporary one.
 func (m *Manager) Query(dbName, query string) ([]string, []map[string]any, error) {
-	m.mu.RLock()
-	dbConfig, ok := m.dbConfigs[dbName]
-	m.mu.RUnlock()
-
-	if !ok {
-		return nil, nil, fmt.Errorf("sink %s not configured", dbName)
-	}
-
-	if dbConfig.Type != "sqlite" {
-		return nil, nil, fmt.Errorf("Query only supported for sqlite sinks")
-	}
-
-	path := dbConfig.DSN
-	if path == "" {
-		path = fmt.Sprintf("./data/sinks/%s.db", dbName)
-	}
-
-	// Open read-only connection with busy_timeout to handle WAL lock contention
-	// When main process is writing to WAL, we need to wait for the lock
-	dsn := fmt.Sprintf("%s?mode=ro&_busy_timeout=5000", path)
-	db, err := sql.Open("sqlite3", dsn)
+	// Get existing sinker to reuse its Reader connection
+	skr, err := m.GetSinker(dbName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("open database: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	// Add LIMIT if not present
-	limitQuery := query
-	if !strings.Contains(strings.ToUpper(query), "LIMIT") {
-		limitQuery = fmt.Sprintf("%s LIMIT 1000", query)
+		return nil, nil, fmt.Errorf("get sinker %s: %w", dbName, err)
 	}
 
-	rows, err := db.Query(limitQuery)
+	// Execute query via sinker (limit 1000 for safety)
+	results, err := skr.Query(query, 1000)
 	if err != nil {
-		return nil, nil, fmt.Errorf("execute query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	// Get column names
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, nil, fmt.Errorf("get columns: %w", err)
+		return nil, nil, fmt.Errorf("query: %w", err)
 	}
 
-	// Get column types to identify datetime columns
-	colTypes, err := rows.ColumnTypes()
-	if err != nil {
-		return nil, nil, fmt.Errorf("get column types: %w", err)
+	// Get columns from first result and sort for stable ordering
+	if len(results) == 0 {
+		return []string{}, []map[string]any{}, nil
 	}
-
-	// Identify datetime columns and attempt to parse time values
-	// Note: SQLite's ColumnTypes() may not return "datetime" for datetime columns
-	// because SQLite uses dynamic typing. We also check for time-like string values.
-	datetimeCols := make(map[int]bool)
-	for i, ct := range colTypes {
-		// SQLite datetime type is stored as "datetime" in schema
-		dbTypeName := ct.DatabaseTypeName()
-		slog.Debug("Query column type", "i", i, "col", columns[i], "dbType", dbTypeName)
-
-		if strings.EqualFold(dbTypeName, "datetime") {
-			datetimeCols[i] = true
-		}
-		// Also mark columns whose names suggest they are datetime
-		colNameLower := strings.ToLower(columns[i])
-		if strings.Contains(colNameLower, "date") || strings.Contains(colNameLower, "time") || strings.Contains(colNameLower, "dt") || strings.Contains(colNameLower, "ts") {
-			datetimeCols[i] = true
-			slog.Debug("Query marked datetime col by name", "col", columns[i])
-		}
+	columns := make([]string, 0, len(results[0]))
+	for col := range results[0] {
+		columns = append(columns, col)
 	}
+	sort.Strings(columns)  // Stable column order for UI display
 
-	slog.Info("Query datetimeCols", "datetimeCols", datetimeCols)
-	results := []map[string]any{}
-	for rows.Next() {
-		values := make([]any, len(columns))
-		valuePtrs := make([]any, len(columns))
-		for i := range values {
-			valuePtrs[i] = &values[i]
-		}
+	// Handle datetime conversion for API response
+	for _, row := range results {
+		for col, val := range row {
+			colNameLower := strings.ToLower(col)
+			isDatetimeCol := strings.Contains(colNameLower, "date") ||
+				strings.Contains(colNameLower, "time") ||
+				strings.Contains(colNameLower, "dt") ||
+				strings.Contains(colNameLower, "ts")
 
-		if err := rows.Scan(valuePtrs...); err != nil {
-			return nil, nil, fmt.Errorf("scan row: %w", err)
-		}
-
-		rowMap := make(map[string]any)
-		for i, col := range columns {
-			val := values[i]
-			// For datetime columns, convert time.Time back to string if it's valid
-			// The SQLite driver sometimes incorrectly converts TEXT datetime columns
-			if t, ok := val.(time.Time); ok {
-				if !t.IsZero() {
-					// Valid time, convert to string
-					val = t.UTC().Format("2006-01-02 15:04:05")
-				} else {
-					// Zero time - keep as null in output
-					val = nil
+			if isDatetimeCol {
+				if t, ok := val.(time.Time); ok {
+					if !t.IsZero() {
+						row[col] = t.UTC().Format("2006-01-02 15:04:05")
+					} else {
+						row[col] = nil
+					}
 				}
 			}
-			rowMap[col] = val
 		}
-		results = append(results, rowMap)
 	}
 
-	return columns, results, rows.Err()
+	return columns, results, nil
 }
 
 // GetTimezone returns the configured MSSQL timezone

--- a/internal/sinker/sinker.go
+++ b/internal/sinker/sinker.go
@@ -32,4 +32,10 @@ type Sinker interface {
 
 	// Close closes the sinker and releases resources
 	Close() error
+
+	// QueryTables returns the list of user tables in the sink database
+	QueryTables() ([]string, error)
+
+	// Query executes a read-only query and returns results
+	Query(query string, limit int) ([]map[string]any, error)
 }

--- a/internal/sinker/sinker.go
+++ b/internal/sinker/sinker.go
@@ -40,6 +40,8 @@ type Sinker interface {
 	// QueryTables returns the list of user tables in the sink database
 	QueryTables() ([]string, error)
 
-	// Query executes a read-only query and returns results
-	Query(query string, limit int) ([]map[string]any, error)
+	// Query executes a read-only query and returns columns and results.
+	// Uses the existing Reader connection instead of creating a temporary one.
+	// Returns columns in SQLite table order (not alphabetically sorted).
+	Query(query string, limit int) ([]string, []map[string]any, error)
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cnlangzi/dbkrab/internal/core"
@@ -260,4 +261,78 @@ func (s *Sinker) Reset(ctx context.Context) error {
 		"tables_cleared", len(tables))
 
 	return nil
+}
+
+// QueryTables returns the list of user tables in the sink database.
+// Uses the existing Reader connection instead of creating a temporary one.
+func (s *Sinker) QueryTables() ([]string, error) {
+	if s.closed {
+		return nil, errors.New("sinker is closed")
+	}
+
+	rows, err := s.db.Reader.Query(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("query tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tables []string
+	for rows.Next() {
+		var tableName string
+		if err := rows.Scan(&tableName); err != nil {
+			continue
+		}
+		// Skip internal SQLite tables
+		if !strings.HasPrefix(tableName, "sqlite_") {
+			tables = append(tables, tableName)
+		}
+	}
+
+	return tables, rows.Err()
+}
+
+// Query executes a read-only query and returns results.
+// Uses the existing Reader connection instead of creating a temporary one.
+func (s *Sinker) Query(query string, limit int) ([]map[string]any, error) {
+	if s.closed {
+		return nil, errors.New("sinker is closed")
+	}
+
+	// Add LIMIT if not present
+	limitQuery := query
+	if limit > 0 && !strings.Contains(strings.ToUpper(query), "LIMIT") {
+		limitQuery = fmt.Sprintf("%s LIMIT %d", query, limit)
+	}
+
+	rows, err := s.db.Reader.Query(limitQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("columns: %w", err)
+	}
+
+	var results []map[string]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		valPtrs := make([]any, len(cols))
+		for i := range vals {
+			valPtrs[i] = &vals[i]
+		}
+
+		if err := rows.Scan(valPtrs...); err != nil {
+			continue
+		}
+
+		row := make(map[string]any)
+		for i, col := range cols {
+			row[col] = vals[i]
+		}
+		results = append(results, row)
+	}
+
+	return results, rows.Err()
 }

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -379,11 +379,12 @@ func (s *Sinker) QueryTables() ([]string, error) {
 	return tables, rows.Err()
 }
 
-// Query executes a read-only query and returns results.
+// Query executes a read-only query and returns columns and results.
 // Uses the existing Reader connection instead of creating a temporary one.
-func (s *Sinker) Query(query string, limit int) ([]map[string]any, error) {
+// Returns columns in SQLite table order (not alphabetically sorted).
+func (s *Sinker) Query(query string, limit int) ([]string, []map[string]any, error) {
 	if s.closed {
-		return nil, errors.New("sinker is closed")
+		return nil, nil, errors.New("sinker is closed")
 	}
 
 	// Add LIMIT if not present
@@ -394,16 +395,16 @@ func (s *Sinker) Query(query string, limit int) ([]map[string]any, error) {
 
 	rows, err := s.db.Reader.Query(limitQuery)
 	if err != nil {
-		return nil, fmt.Errorf("query: %w", err)
+		return nil, nil, fmt.Errorf("query: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	cols, err := rows.Columns()
 	if err != nil {
-		return nil, fmt.Errorf("columns: %w", err)
+		return nil, nil, fmt.Errorf("columns: %w", err)
 	}
 
-	var results []map[string]any
+	var res []map[string]any
 	for rows.Next() {
 		vals := make([]any, len(cols))
 		valPtrs := make([]any, len(cols))
@@ -419,8 +420,9 @@ func (s *Sinker) Query(query string, limit int) ([]map[string]any, error) {
 		for i, col := range cols {
 			row[col] = vals[i]
 		}
-		results = append(results, row)
+		res = append(res, row)
 	}
 
-	return results, rows.Err()
+	// Return columns in SQLite order, not alphabetically sorted
+	return cols, res, rows.Err()
 }


### PR DESCRIPTION
## Problem

Manager.QueryTables and Query created temporary SQLite connections instead of using the existing Sinker's Reader connection.

This caused "database disk image is malformed" errors when the main process was writing to WAL, because temporary connections had no busy_timeout configured.

## Root Cause

- Manager opened new connections: `sql.Open("sqlite3", path+"?mode=ro")`
- Should reuse existing Reader that already has `_busy_timeout=5000`

## Solution

1. Add `QueryTables()` and `Query()` methods to Sinker interface
2. Implement in sqlite.Sinker using `s.db.Reader`
3. Manager now calls `GetSinker(dbName)` → `sinker.QueryTables()`
4. Remove unused imports (database/sql, mattn/go-sqlite3)

## Changes

- `internal/sinker/sinker.go`: Add QueryTables/Query to interface
- `internal/sinker/sqlite/writer.go`: Implement methods using Reader
- `internal/sinker/manager.go`: Delegate to sinker methods, add sort.Strings for stable column order

## Testing

- All tests pass
- Deployed locally, business sink database page works correctly