### PR TITLE
fix(cdc): use per-table LSN tracking for gap monitor

### DIFF
--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -69,6 +70,7 @@ type Server struct {
 	metricsProvider PollMetricsProvider // Provides CDC poll metrics
 	runtime         *core.Runtime       // Runtime for capturer management
 	poller          interface{}         // CDC poller (deprecated, use Runtime/Capturer)
+	offsetStore     offset.StoreInterface // Per-table offset tracking
 }
 
 // NewServer creates a new API server with all features
@@ -110,6 +112,7 @@ func NewServer(
 		skillsPath:    skillsPath,
 		poller:        poller,
 		runtime:       runtime,
+		offsetStore:   offsetStore,
 	}
 }
 
@@ -715,14 +718,24 @@ func (s *Server) handleCDCGap(c *xun.Context) error {
 	gapDetector := cdc.NewGapDetector(db)
 	ctx := context.Background()
 
-	// Get CDC max LSN once (shared across all tables)
+	// Load offsetStore data for per-table LSN tracking
+	// This ensures we have the latest offsets from the offset database
+	if s.offsetStore != nil {
+		if err := s.offsetStore.Load(); err != nil {
+			slog.Warn("failed to load offset store", "error", err)
+		}
+	}
+
+	// Get a global max LSN for backward compatibility response
+	var globalMaxLSN []byte
 	maxLSN, err := gapDetector.GetMaxLSN(ctx)
 	if err != nil {
 		return c.View(map[string]any{
 			"success": false,
-			"error":   fmt.Sprintf("get max LSN: %v", err),
+			"error":   fmt.Sprintf("get global max LSN: %v", err),
 		})
 	}
+	globalMaxLSN = maxLSN
 
 	// Collect gap info for all tracked tables
 	gapInfos := make([]map[string]any, 0, len(trackedTables))
@@ -735,23 +748,29 @@ func (s *Server) handleCDCGap(c *xun.Context) error {
 		schema, name := parts[0], parts[1]
 		captureInstance := fmt.Sprintf("%s_%s", schema, name)
 
-		// Get current LSN from poller state (approximation - in real scenario would track per-table)
-		// For now, use the global last_lsn from poller state
-		state, err := s.store.GetPollerState()
+		// Get current LSN from offset store (per-table tracking)
+		var currentLSN []byte
+		if s.offsetStore != nil {
+			offset, err := s.offsetStore.Get(table)
+			if err == nil && offset.LastLSN != "" {
+				// Convert hex string to bytes
+				currentLSN, err = hex.DecodeString(offset.LastLSN)
+				if err != nil {
+					slog.Warn("failed to decode current LSN", "table", table, "lsn", offset.LastLSN, "error", err)
+					currentLSN = nil
+				}
+			}
+		}
+
+		// Get per-table max LSN from CDC system tables
+		tableMaxLSN, err := gapDetector.GetTableMaxLSN(ctx, captureInstance)
 		if err != nil {
-			slog.Warn("failed to get poller state", "table", table, "error", err)
+			slog.Warn("failed to get table max LSN", "table", table, "error", err)
 			continue
 		}
 
-		var currentLSN []byte
-		if lsnStr, ok := state["last_lsn"].(string); ok && lsnStr != "" {
-			// Convert hex string back to bytes if needed
-			// For now, we'll query the actual current LSN from CDC
-			currentLSN = maxLSN // Use max as approximation
-		}
-
 		// Check gap for this table
-		gapInfo, err := gapDetector.CheckGap(ctx, table, captureInstance, currentLSN)
+		gapInfo, err := gapDetector.CheckGap(ctx, table, captureInstance, currentLSN, tableMaxLSN)
 		if err != nil {
 			slog.Warn("failed to check gap", "table", table, "error", err)
 			continue
@@ -793,7 +812,7 @@ func (s *Server) handleCDCGap(c *xun.Context) error {
 		"success": true,
 		"count":   len(gapInfos),
 		"tables":  gapInfos,
-		"max_lsn": formatLSN(maxLSN),
+		"max_lsn": formatLSN(globalMaxLSN),
 		"thresholds": map[string]any{
 			"warning_lag_bytes":     warnLagBytes,
 			"warning_lag_duration":  warnLagDuration.String(),
@@ -1136,7 +1155,7 @@ func (s *Server) collectOverviewMetrics() OverviewMetrics {
 						schema, name := parts[0], parts[1]
 						captureInstance := fmt.Sprintf("%s_%s", schema, name)
 
-						gapInfo, err := gapDetector.CheckGap(ctx, table, captureInstance, currentLSN)
+						gapInfo, err := gapDetector.CheckGap(ctx, table, captureInstance, currentLSN, nil)
 						if err != nil {
 							continue
 						}

--- a/internal/cdc/gap_detector.go
+++ b/internal/cdc/gap_detector.go
@@ -41,7 +41,8 @@ func NewGapDetector(db *sql.DB) *GapDetector {
 // CheckGap checks for CDC gaps and lag for a specific table
 // tableName: original table name in schema.table format
 // captureInstance: CDC capture instance name
-func (d *GapDetector) CheckGap(ctx context.Context, tableName, captureInstance string, currentLSN []byte) (GapInfo, error) {
+// tableMaxLSN: optional per-table max LSN. If nil, uses global max LSN.
+func (d *GapDetector) CheckGap(ctx context.Context, tableName, captureInstance string, currentLSN []byte, tableMaxLSN []byte) (GapInfo, error) {
 	gap := GapInfo{
 		Table:           tableName,
 		CaptureInstance: captureInstance,
@@ -56,12 +57,16 @@ func (d *GapDetector) CheckGap(ctx context.Context, tableName, captureInstance s
 	}
 	gap.MinLSN = minLSN
 
-	// Get CDC max LSN (latest change)
-	maxLSN, err := d.GetMaxLSN(ctx)
-	if err != nil {
-		return gap, fmt.Errorf("get max LSN: %w", err)
+	// Get CDC max LSN (latest change) - use per-table if provided, otherwise global
+	if len(tableMaxLSN) > 0 {
+		gap.MaxLSN = tableMaxLSN
+	} else {
+		maxLSN, err := d.GetMaxLSN(ctx)
+		if err != nil {
+			return gap, fmt.Errorf("get max LSN: %w", err)
+		}
+		gap.MaxLSN = maxLSN
 	}
-	gap.MaxLSN = maxLSN
 
 	// Check if current LSN is behind min LSN (data loss)
 	if len(currentLSN) > 0 && len(minLSN) > 0 {
@@ -76,15 +81,15 @@ func (d *GapDetector) CheckGap(ctx context.Context, tableName, captureInstance s
 	}
 
 	// Calculate lag in bytes (max_lsn - current_lsn)
-	if len(maxLSN) > 0 && len(currentLSN) > 0 {
-		gap.LagBytes = LSNBytesDiff(maxLSN, currentLSN)
+	if len(gap.MaxLSN) > 0 && len(currentLSN) > 0 {
+		gap.LagBytes = LSNBytesDiff(gap.MaxLSN, currentLSN)
 	}
 
 	// Estimate lag duration (requires querying LSN time mapping)
-	if len(currentLSN) > 0 && len(maxLSN) > 0 {
+	if len(currentLSN) > 0 && len(gap.MaxLSN) > 0 {
 		currentTime, err := d.GetLSNTime(ctx, currentLSN)
 		if err == nil {
-			maxTime, err := d.GetLSNTime(ctx, maxLSN)
+			maxTime, err := d.GetLSNTime(ctx, gap.MaxLSN)
 			if err == nil {
 				gap.LagDuration = maxTime.Sub(currentTime)
 			}
@@ -112,6 +117,28 @@ func (d *GapDetector) GetMaxLSN(ctx context.Context) ([]byte, error) {
 	var lsn []byte
 	err := d.db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_max_lsn()").Scan(&lsn)
 	return lsn, err
+}
+
+// GetTableMaxLSN returns the max LSN for a specific capture instance (per-table)
+// This queries the CDC change table (CT) to get the actual max LSN for each table's changes.
+// If the change table is empty or doesn't exist, returns nil (caller should fallback to global max LSN).
+func (d *GapDetector) GetTableMaxLSN(ctx context.Context, captureInstance string) ([]byte, error) {
+	// Validate capture instance to prevent SQL injection
+	if !validCaptureInstance.MatchString(captureInstance) {
+		return nil, fmt.Errorf("invalid capture instance name: %s", captureInstance)
+	}
+
+	var lsn []byte
+	// Query the CDC change table (CT) for the maximum __$start_lsn
+	// The CT table name follows the pattern: cdc.<capture_instance>_CT
+	ctTable := fmt.Sprintf("cdc.%s_CT", captureInstance)
+	query := fmt.Sprintf("SELECT MAX(__$start_lsn) FROM %s", ctTable)
+	err := d.db.QueryRowContext(ctx, query).Scan(&lsn)
+	if err != nil {
+		return nil, fmt.Errorf("query table max LSN from %s: %w", ctTable, err)
+	}
+	// lsn will be nil if the table is empty (no changes yet)
+	return lsn, nil
 }
 
 // GetLSNTime returns the timestamp for a given LSN


### PR DESCRIPTION
Fixes: #229

## What Changed
- Added `offsetStore` field to Server struct and initialized it in `NewServer`
- Updated `handleCDCGap` to fetch `last_lsn` per table via `offsetStore.Get(table)`
- Implemented `GetTableMaxLSN(captureInstance)` in gap detector to query per-table MaxLSN from MSSQL CDC system tables
- Calculate lag as `MaxLSN - last_lsn` and detect data loss when `last_lsn < MinLSN`

## Why
The previous implementation used a global MSSQL MaxLSN and set `currentLSN = maxLSN`, causing lag to always calculate to zero. This masked real replication gaps and potential data loss. The `offsetStore` was passed to the Server constructor but never stored or utilized, leaving per-table progress tracking unused.

## How to Test
1. Call `/api/cdc/gap` endpoint and verify `current_lsn` and `max_lsn` are distinct per table
2. Confirm lag calculation computes `max_csn - current_csn` correctly
3. Verify status transitions to warning/critical when lag exceeds configured thresholds
4. Confirm data loss flag triggers when `current_lsn` falls below MSSQL MinLSN cleanup boundary

Fixes #229