### PR TITLE
refactor(snapshot): remove offset checkpoint persistence from SnapshotCapturer

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -243,7 +243,7 @@ func main() {
 	snapshotConfig := &snapshot.Config{BatchSize: cfg.Snapshot.BatchSize}
 	snapshotQuerier := snapshot.NewQuerier(mssqlDB, config.ParseTimezone(cfg.MSSQL.Timezone), snapshotConfig)
 	snapshotTables := snapshot.GetCDCTables(cfg)
-	snapshotCapturer := snapshot.NewSnapshotCapturer(snapshotQuerier, snapshotTables, offsetStore)
+	snapshotCapturer := snapshot.NewSnapshotCapturer(snapshotQuerier, snapshotTables)
 
 	// Create replay capturer (reuses appStore which implements Store interface)
 	replayCapturer := replay.NewReplayCapturer(appStore)

--- a/internal/snapshot/capturer.go
+++ b/internal/snapshot/capturer.go
@@ -3,7 +3,6 @@ package snapshot
 import (
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -12,13 +11,17 @@ import (
 
 	"github.com/cnlangzi/dbkrab/internal/config"
 	"github.com/cnlangzi/dbkrab/internal/core"
-	"github.com/cnlangzi/dbkrab/internal/offset"
 )
 
 // CDCTable represents a CDC-enabled table.
 type CDCTable struct {
 	Schema string
 	Name   string
+}
+
+// FullName returns the schema-qualified table name.
+func (t CDCTable) FullName() string {
+	return t.Schema + "." + t.Name
 }
 
 // GetCDCTables returns CDC-enabled tables from config.
@@ -69,15 +72,14 @@ type Progress struct {
 //     discovers PKs and approximate row counts for all tables.
 //  2. Runtime calls Fetch(ctx) repeatedly — each call fetches one batch (BatchSize rows)
 //     from the current table using the open transaction.
-//  3. When a table is exhausted the LSN checkpoint is saved to offsetStore so CDC
-//     can resume from the correct position.
+//  3. When a table is exhausted CDC will automatically pick up from min_lsn (cold start),
+//     replaying changes idempotently — no offset checkpoint needed.
 //  4. When all tables are done the transaction is committed and NextCapturer: CapturerCDC
 //     is returned.
 type SnapshotCapturer struct {
 	querier       *Querier
 	tables        []CDCTable
 	pendingTables []CDCTable // staged tables from UpdateTables, applied in Restart
-	offsetStore   offset.StoreInterface
 
 	mu           sync.Mutex
 	pending      bool // set by Restart before DB init; reports as Started so status shows "running"
@@ -85,7 +87,6 @@ type SnapshotCapturer struct {
 	completed    bool
 	stopped      bool
 	tx           *sql.Tx // open snapshot-isolation transaction; nil until Restart succeeds
-	startLSN     []byte  // MaxLSN captured before snapshot tx; stable CDC resume point
 	tableIndex   int
 	rowOffset    int // row offset within current table
 	currentTable string
@@ -99,11 +100,10 @@ type SnapshotCapturer struct {
 }
 
 // NewSnapshotCapturer creates a new SnapshotCapturer.
-func NewSnapshotCapturer(querier *Querier, tables []CDCTable, offsetStore offset.StoreInterface) *SnapshotCapturer {
+func NewSnapshotCapturer(querier *Querier, tables []CDCTable) *SnapshotCapturer {
 	return &SnapshotCapturer{
-		querier:     querier,
-		tables:      tables,
-		offsetStore: offsetStore,
+		querier: querier,
+		tables:  tables,
 	}
 }
 
@@ -126,7 +126,6 @@ func (c *SnapshotCapturer) Restart(ctx context.Context, selectedTables []CDCTabl
 	c.completed = false
 	c.stopped = false
 	c.tx = nil
-	c.startLSN = nil
 	c.tableIndex = 0
 	c.rowOffset = 0
 	c.currentTable = ""
@@ -151,18 +150,9 @@ func (c *SnapshotCapturer) Restart(ctx context.Context, selectedTables []CDCTabl
 		return fmt.Errorf("snapshot isolation check: %w", err)
 	}
 
-	// 2b. Capture MaxLSN outside any transaction — this is the stable CDC resume point.
-	//     All tables will use this same LSN so CDC can resume correctly after snapshot.
-	startLSN, err := c.querier.GetMaxLSN(ctx)
-	if err != nil {
-		c.markError(fmt.Sprintf("capture max LSN: %v", err))
-		return fmt.Errorf("capture max LSN: %w", err)
-	}
-	slog.Info("SnapshotCapturer: captured start LSN", "lsn", hex.EncodeToString(startLSN))
-
-	// 2c. Open ONE snapshot-isolation transaction covering all table reads.
+	// 2b. Open ONE snapshot-isolation transaction covering all table reads.
 	//     Snapshot isolation gives a consistent MVCC read view — new DML on the source
-	//     during snapshot will NOT be visible, ensuring MaxLSN stays valid.
+	//     during snapshot will NOT be visible.
 	//     IMPORTANT: Use context.Background() (not the caller's HTTP-request context) so
 	//     the transaction is NOT automatically rolled back when the HTTP handler returns.
 	tx, err := c.querier.BeginSnapshotTx(context.Background())
@@ -171,7 +161,7 @@ func (c *SnapshotCapturer) Restart(ctx context.Context, selectedTables []CDCTabl
 		return fmt.Errorf("begin snapshot tx: %w", err)
 	}
 
-	// 2d. Per-table setup: approximate row count + PK discovery.
+	// 2c. Per-table setup: approximate row count + PK discovery.
 	n := len(selectedTables)
 	tableTotals := make([]int64, n)
 	tableRead := make([]int64, n)
@@ -179,7 +169,7 @@ func (c *SnapshotCapturer) Restart(ctx context.Context, selectedTables []CDCTabl
 	tablePKs := make([]*PrimaryKeyInfo, n)
 
 	for i, t := range selectedTables {
-		fullName := fmt.Sprintf("%s.%s", t.Schema, t.Name)
+		fullName := t.FullName()
 
 		count, countErr := c.querier.GetApproxRowCount(ctx, t.Schema, t.Name)
 		if countErr != nil {
@@ -204,7 +194,6 @@ func (c *SnapshotCapturer) Restart(ctx context.Context, selectedTables []CDCTabl
 	// Phase 3: commit initialised state under mutex.
 	c.mu.Lock()
 	c.tx = tx
-	c.startLSN = startLSN
 	c.tableTotals = tableTotals
 	c.tableRead = tableRead
 	c.tableDone = tableDone
@@ -282,7 +271,7 @@ func (c *SnapshotCapturer) Progress() Progress {
 	var totalRows, readRows int64
 	for i, t := range c.tables {
 		tp := TableProgress{
-			Table: fmt.Sprintf("%s.%s", t.Schema, t.Name),
+			Table: t.FullName(),
 		}
 		if i < len(c.tableTotals) {
 			tp.TotalRows = c.tableTotals[i]
@@ -375,7 +364,7 @@ func (c *SnapshotCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 	batchSize := c.querier.config.BatchSize
 	offset := c.rowOffset
 	tx := c.tx
-	c.currentTable = fmt.Sprintf("%s.%s", table.Schema, table.Name)
+	c.currentTable = table.FullName()
 
 	c.mu.Unlock()
 
@@ -435,13 +424,11 @@ func (c *SnapshotCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 		c.rowOffset = 0
 	}
 
-	startLSN := c.startLSN // capture for offset saving (outside lock)
 	c.mu.Unlock()
 
 	if isLastBatch || len(batchRows) == 0 {
 		slog.Info("SnapshotCapturer: table completed",
 			"table", c.currentTable, "read_rows", readSoFar)
-		c.saveTableOffset(ctx, tableIdx, startLSN)
 	}
 
 	if len(batchRows) == 0 {
@@ -465,34 +452,6 @@ func (c *SnapshotCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 		BatchID:      batchCtx.BatchID,
 		NextCapturer: core.CapturerSnapshot,
 	}
-}
-
-// saveTableOffset persists the CDC-resume LSN checkpoint for a completed table.
-// Must be called without holding the mutex.
-func (c *SnapshotCapturer) saveTableOffset(ctx context.Context, tableIdx int, startLSN []byte) {
-	if c.offsetStore == nil || len(startLSN) == 0 {
-		return
-	}
-	table := c.tables[tableIdx]
-	fullName := fmt.Sprintf("%s.%s", table.Schema, table.Name)
-
-	nextLSN, err := c.querier.IncrementLSN(ctx, startLSN)
-	if err != nil {
-		slog.Warn("SnapshotCapturer: increment LSN failed", "table", fullName, "error", err)
-		return
-	}
-	startStr := hex.EncodeToString(startLSN)
-	nextStr := hex.EncodeToString(nextLSN)
-	if err := c.offsetStore.Set(fullName, startStr, nextStr); err != nil {
-		slog.Warn("SnapshotCapturer: set offset failed", "table", fullName, "error", err)
-		return
-	}
-	if err := c.offsetStore.Flush(); err != nil {
-		slog.Warn("SnapshotCapturer: flush offset failed", "table", fullName, "error", err)
-		return
-	}
-	slog.Info("SnapshotCapturer: offset saved",
-		"table", fullName, "start_lsn", startStr, "next_lsn", nextStr)
 }
 
 // Ensure SnapshotCapturer satisfies the Capturer interface.

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -170,13 +170,6 @@ func (q *Querier) CheckSnapshotIsolation(ctx context.Context) error {
 	return nil
 }
 
-// IncrementLSN returns the next LSN after the given one
-func (q *Querier) IncrementLSN(ctx context.Context, lsn []byte) ([]byte, error) {
-	var nextLSN []byte
-	err := q.db.QueryRowContext(ctx, "SELECT sys.fn_cdc_increment_lsn(@p1)", lsn).Scan(&nextLSN)
-	return nextLSN, err
-}
-
 // GetApproxRowCount returns the approximate row count for a table using sys.partitions.
 // This avoids a full COUNT(*) scan and returns results in milliseconds.
 // The count may be slightly off if rows were inserted/deleted recently and stats not yet updated.
@@ -428,68 +421,4 @@ type TableHandlerFunc func(ctx context.Context, changes []core.Change) error
 // HandleTable implements the TableHandler interface by calling the function itself.
 func (f TableHandlerFunc) HandleTable(ctx context.Context, changes []core.Change) error {
 	return f(ctx, changes)
-}
-
-// OffsetUpdater updates offset storage after snapshot completes.
-// It persists the LSN checkpoint so subsequent CDC sync can resume correctly.
-type OffsetUpdater interface {
-	Set(table string, lastLSN string, nextLSN string) error
-	Flush() error
-}
-
-// Runner coordinates full snapshot run with offset update.
-// It runs the snapshot querier and persists the resulting LSN checkpoint.
-type Runner struct {
-	querier     *Querier
-	offsetStore OffsetUpdater
-}
-
-// NewRunner creates a new snapshot Runner with the given querier and offset store.
-func NewRunner(querier *Querier, offsetStore OffsetUpdater) *Runner {
-	return &Runner{
-		querier:     querier,
-		offsetStore: offsetStore,
-	}
-}
-
-// RunFull runs snapshot for a table and updates offset store on success.
-// The schema parameter should be like "dbo", and table is the table name without schema.
-// After snapshot completes, the LSN checkpoint is stored so CDC can resume.
-func (r *Runner) RunFull(ctx context.Context, schema, table string, handler TableHandler) error {
-	fullTableName := schema + "." + table
-
-	// Run snapshot and get start LSN checkpoint
-	startLSN, err := r.querier.Run(ctx, schema, table, handler)
-	if err != nil {
-		return fmt.Errorf("snapshot run: %w", err)
-	}
-
-	// Calculate next LSN for CDC to resume from
-	// CDC should start from increment(startLSN), not startLSN itself
-	// This ensures no duplicates with snapshot data
-	nextLSN, err := r.querier.IncrementLSN(ctx, startLSN)
-	if err != nil {
-		return fmt.Errorf("increment LSN: %w", err)
-	}
-
-	// Update offset store with startLSN and nextLSN
-	// last_lsn = startLSN (the checkpoint captured before snapshot)
-	// next_lsn = increment(startLSN) (where CDC should resume)
-	startLSNStr := hex.EncodeToString(startLSN)
-	nextLSNStr := hex.EncodeToString(nextLSN)
-
-	if err := r.offsetStore.Set(fullTableName, startLSNStr, nextLSNStr); err != nil {
-		return fmt.Errorf("set offset: %w", err)
-	}
-
-	if err := r.offsetStore.Flush(); err != nil {
-		return fmt.Errorf("flush offset: %w", err)
-	}
-
-	slog.Info("snapshot: offset updated",
-		"table", fullTableName,
-		"last_lsn", startLSNStr,
-		"next_lsn", nextLSNStr)
-
-	return nil
 }

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -151,35 +151,6 @@ func (h *testHandler) HandleTable(ctx context.Context, changes []core.Change) er
 	return nil
 }
 
-// testOffsetStore implements OffsetUpdater for testing
-type testOffsetStore struct {
-	offsets map[string]struct{ last, next string }
-	flushes int
-}
-
-func newTestOffsetStore() *testOffsetStore {
-	return &testOffsetStore{
-		offsets: make(map[string]struct{ last, next string }),
-	}
-}
-
-func (s *testOffsetStore) Set(table string, lastLSN, nextLSN string) error {
-	s.offsets[table] = struct{ last, next string }{lastLSN, nextLSN}
-	return nil
-}
-
-func (s *testOffsetStore) Flush() error {
-	s.flushes++
-	return nil
-}
-
-func (s *testOffsetStore) Get(table string) (string, string, bool) {
-	if o, ok := s.offsets[table]; ok {
-		return o.last, o.next, true
-	}
-	return "", "", false
-}
-
 func TestNewQuerier_WithDefaults(t *testing.T) {
 	config := DefaultConfig()
 
@@ -222,43 +193,6 @@ func TestHandlerFunc(t *testing.T) {
 	}
 	if len(captured) != 1 {
 		t.Errorf("captured changes count = %d, want 1", len(captured))
-	}
-}
-
-func TestRunner_OffsetUpdate(t *testing.T) {
-	store := newTestOffsetStore()
-
-	err := store.Set("dbo.test_table", "000000000000000001", "000000000000000002")
-	if err != nil {
-		t.Errorf("Set error = %v", err)
-	}
-
-	last, next, ok := store.Get("dbo.test_table")
-	if !ok {
-		t.Error("offset not found")
-	}
-	if last != "000000000000000001" {
-		t.Errorf("last LSN = %s, want 000000000000000001", last)
-	}
-	if next != "000000000000000002" {
-		t.Errorf("next LSN = %s, want 000000000000000002", next)
-	}
-
-	err = store.Flush()
-	if err != nil {
-		t.Errorf("Flush error = %v", err)
-	}
-	if store.flushes != 1 {
-		t.Errorf("flush count = %d, want 1", store.flushes)
-	}
-}
-
-func TestRunner_GetNonExistentOffset(t *testing.T) {
-	store := newTestOffsetStore()
-
-	_, _, ok := store.Get("dbo.non_existent")
-	if ok {
-		t.Error("should not find non-existent offset")
 	}
 }
 


### PR DESCRIPTION
## Summary

CDC now resumes from `min_lsn` on cold start with idempotent replay, making per-table LSN checkpointing unnecessary. This removes 3 synchronous I/O operations per completed table (`IncrementLSN`, `Set`, `Flush`).

Also removes orphaned `Runner`/`OffsetUpdater` code path which was never called from production code, along with its `testOffsetStore` and associated tests.

## Changes

- Remove `offsetStore` parameter and field from `SnapshotCapturer`
- Remove `saveTableOffset` method and associated `startLSN` field
- Remove `GetMaxLSN` call in `Restart()` — LSN capture no longer needed
- Add `CDCTable.FullName()` helper to replace inline `fmt.Sprintf` calls
- Remove dead `Runner`/`NewRunner`/`RunFull()` (never called)
- Remove `OffsetUpdater` interface (only used by `Runner`)
- Remove `snapshot.Querier.IncrementLSN` (only called by `Runner`)
- Remove `testOffsetStore` and `TestRunner_*` tests

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Verify CDC cold-start from `min_lsn` produces no duplicate rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)