### PR TITLE
Unify time formatting in Query() by using types.Codec

### DIFF
--- a/internal/sinker/manager.go
+++ b/internal/sinker/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -313,6 +312,7 @@ func (m *Manager) Truncate(ctx context.Context, dbName string, tables []string) 
 
 // Query executes a read-only SELECT query on a sink and returns results.
 // Uses the Sinker's existing Reader connection instead of creating a temporary one.
+// Time formatting is handled by types.Codec in the sinker.Query() method.
 func (m *Manager) Query(dbName, query string) ([]string, []map[string]any, error) {
 	// Get existing sinker to reuse its Reader connection
 	skr, err := m.GetSinker(dbName)
@@ -321,31 +321,10 @@ func (m *Manager) Query(dbName, query string) ([]string, []map[string]any, error
 	}
 
 	// Execute query via sinker (limit 1000 for safety)
-	// Returns columns in SQLite table order
+	// Time columns are automatically formatted to "2006-01-02 15:04:05" by types.Codec
 	columns, results, err := skr.Query(query, 1000)
 	if err != nil {
 		return nil, nil, fmt.Errorf("query: %w", err)
-	}
-
-	// Handle datetime conversion for API response
-	for _, row := range results {
-		for col, val := range row {
-			colNameLower := strings.ToLower(col)
-			isDatetimeCol := strings.Contains(colNameLower, "date") ||
-				strings.Contains(colNameLower, "time") ||
-				strings.Contains(colNameLower, "dt") ||
-				strings.Contains(colNameLower, "ts")
-
-			if isDatetimeCol {
-				if t, ok := val.(time.Time); ok {
-					if !t.IsZero() {
-						row[col] = t.UTC().Format("2006-01-02 15:04:05")
-					} else {
-						row[col] = nil
-					}
-				}
-			}
-		}
 	}
 
 	return columns, results, nil

--- a/internal/sinker/sqlite/writer.go
+++ b/internal/sinker/sqlite/writer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cnlangzi/dbkrab/internal/core"
 	"github.com/cnlangzi/dbkrab/internal/sqliteutil"
+	"github.com/cnlangzi/dbkrab/internal/types"
 	"github.com/yaitoo/sqle"
 	"github.com/yaitoo/sqle/migrate"
 )
@@ -347,6 +348,7 @@ func (s *Sinker) QueryTables() ([]string, error) {
 // Query executes a read-only query and returns columns and results.
 // Uses the existing Reader connection instead of creating a temporary one.
 // Returns columns in SQLite table order (not alphabetically sorted).
+// Time columns are automatically formatted to "2006-01-02 15:04:05" via types.Codec.
 func (s *Sinker) Query(query string, limit int) ([]string, []map[string]any, error) {
 	if s.closed {
 		return nil, nil, errors.New("sinker is closed")
@@ -369,21 +371,36 @@ func (s *Sinker) Query(query string, limit int) ([]string, []map[string]any, err
 		return nil, nil, fmt.Errorf("columns: %w", err)
 	}
 
+	// Get column types for typed scanning
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, nil, fmt.Errorf("column types: %w", err)
+	}
+
+	// Create SQLite codec - DATETIME/TIMESTAMP columns will use NullTime scanner
+	codec := types.NewSQLiteCodec()
+
 	var res []map[string]any
 	for rows.Next() {
-		vals := make([]any, len(cols))
-		valPtrs := make([]any, len(cols))
-		for i := range vals {
-			valPtrs[i] = &vals[i]
-		}
+		// Create typed scan destinations based on column types
+		dest := codec.CreateDest(colTypes)
 
-		if err := rows.Scan(valPtrs...); err != nil {
+		if err := rows.Scan(dest...); err != nil {
 			continue
 		}
 
+		// Extract values from scanners, calling .Value() for unified formatting
 		row := make(map[string]any)
 		for i, col := range cols {
-			row[col] = vals[i]
+			if scanner, ok := dest[i].(types.DBType); ok {
+				if val, err := scanner.Value(); err == nil {
+					row[col] = val
+				} else {
+					row[col] = nil
+				}
+			} else {
+				row[col] = dest[i]
+			}
 		}
 		res = append(res, row)
 	}


### PR DESCRIPTION
What changed:
- Query() now uses the shared types.Codec to marshal/unmarshal time values so the time format is consistent across all query responses.
- Replaced ad-hoc time formatting logic with codec-based serialization to ensure identical encoding/decoding behavior.

Why it changed:
- Previously there were inconsistencies in how time fields were serialized in query responses, which caused parsing issues and test flakes. Using types.Codec centralizes the format and eliminates divergence.

How to test:
1. Run unit and integration tests: go test ./... (or the project's test command) to ensure no regressions.
2. Execute a query that returns time fields (e.g., via the HTTP/GRPC query endpoint) and verify the time string matches the codec's format (roundtrip parse with the same types.Codec should succeed).
3. Compare previous outputs to ensure the format is now consistent across endpoints and modules.
4. Run any existing serialization tests and add a small test that serializes and deserializes a time through Query() to confirm stability.