### PR TITLE
Preserve source timezone when formatting NullTime outputs

### DIFF
--- a/internal/cdc/types_test.go
+++ b/internal/cdc/types_test.go
@@ -385,9 +385,9 @@ func TestDateTimeScanValue(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			// A string already carries explicit timezone (Z = UTC); no reinterpretation.
-			// Value() now outputs in configured timezone (Shanghai), so UTC time appears as Shanghai.
-			name:    "RFC3339 string stays as-is",
+			// RFC3339 string carries explicit timezone (Z = UTC); parsed into UTC.
+			// Value() outputs in configured timezone (Shanghai), so UTC time is converted.
+			name:    "RFC3339 string converted to configured timezone",
 			src:     "2026-04-09T12:26:00Z",
 			wantVal: "2026-04-09 20:26:00",
 			wantNil: false,

--- a/internal/cdc/types_test.go
+++ b/internal/cdc/types_test.go
@@ -373,9 +373,10 @@ func TestDateTimeScanValue(t *testing.T) {
 		{
 			// Driver delivers time.Time tagged as UTC but it's actually Shanghai local time.
 			// NullTime reinterprets the wall clock in Shanghai and converts it to UTC.
+			// Value() now outputs in Shanghai timezone, so wall clock time is preserved.
 			name:    "valid time.Time (driver UTC, reinterpreted as Shanghai)",
 			src:     time.Date(2026, 4, 9, 12, 26, 0, 0, time.UTC),
-			wantVal: "2026-04-09 04:26:00",
+			wantVal: "2026-04-09 12:26:00",
 			wantNil: false,
 		},
 		{
@@ -385,9 +386,10 @@ func TestDateTimeScanValue(t *testing.T) {
 		},
 		{
 			// A string already carries explicit timezone (Z = UTC); no reinterpretation.
+			// Value() now outputs in configured timezone (Shanghai), so UTC time appears as Shanghai.
 			name:    "RFC3339 string stays as-is",
 			src:     "2026-04-09T12:26:00Z",
-			wantVal: "2026-04-09 12:26:00",
+			wantVal: "2026-04-09 20:26:00",
 			wantNil: false,
 		},
 	}

--- a/internal/types/codec_test.go
+++ b/internal/types/codec_test.go
@@ -131,8 +131,9 @@ func TestSQLiteCodecCreate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Value: %v", err)
 		}
-		// 2026-04-09 12:00:00 Shanghai (UTC+8) → 2026-04-09 04:00:00 UTC → "2026-04-09 04:00:00"
-		want := "2026-04-09 04:00:00"
+		// 2026-04-09 12:00:00 Shanghai (UTC+8) → 2026-04-09 04:00:00 UTC (stored)
+		// Value() now outputs in configured timezone (Shanghai), so wall clock is preserved.
+		want := "2026-04-09 12:00:00"
 		if got != want {
 			t.Errorf("Value() = %q, want %q", got, want)
 		}

--- a/internal/types/time.go
+++ b/internal/types/time.go
@@ -152,15 +152,19 @@ func (m NullTime) reinterpret(driverTime time.Time) time.Time {
 }
 
 func (m NullTime) formatOutput() interface{} {
+	tz := m.timezone
+	if tz == nil {
+		tz = time.UTC
+	}
 	switch m.effectiveFormat() {
 	case TimeFormatRFC3339:
-		return m.val.Format(time.RFC3339)
+		return m.val.In(tz).Format(time.RFC3339)
 	case TimeFormatRFC3339Nano:
-		return m.val.Format(time.RFC3339Nano)
+		return m.val.In(tz).Format(time.RFC3339Nano)
 	case TimeFormatDatetime:
-		return m.val.UTC().Format("2006-01-02 15:04:05")
+		return m.val.In(tz).Format("2006-01-02 15:04:05")
 	case TimeFormatDate:
-		return m.val.UTC().Format("2006-01-02")
+		return m.val.In(tz).Format("2006-01-02")
 	case TimeFormatUnix:
 		return m.val.Unix()
 	case TimeFormatUnixMilli:
@@ -168,7 +172,7 @@ func (m NullTime) formatOutput() interface{} {
 	case TimeFormatUnixNano:
 		return m.val.UnixNano()
 	default:
-		return m.val.UTC().Format(string(m.effectiveFormat()))
+		return m.val.In(tz).Format(string(m.effectiveFormat()))
 	}
 }
 
@@ -179,13 +183,17 @@ func (m NullTime) Value() (driver.Value, error) {
 	if !m.valid || m.val.IsZero() {
 		return nil, nil
 	}
+	tz := m.timezone
+	if tz == nil {
+		tz = time.UTC
+	}
 	switch v := m.formatOutput().(type) {
 	case string:
 		return v, nil
 	case int64:
 		return v, nil
 	}
-	return m.val.UTC(), nil
+	return m.val.In(tz), nil
 }
 
 func (m NullTime) MarshalJSON() ([]byte, error) {

--- a/internal/types/time.go
+++ b/internal/types/time.go
@@ -87,6 +87,15 @@ func (m NullTime) effectiveFormat() TimeFormat {
 	return DefaultTimeFormat
 }
 
+// outputLocation returns the timezone to use for formatting output.
+// Defaults to UTC when no timezone is configured.
+func (m NullTime) outputLocation() *time.Location {
+	if m.timezone == nil {
+		return time.UTC
+	}
+	return m.timezone
+}
+
 func (m *NullTime) Scan(src interface{}) error {
 	if src == nil {
 		m.val, m.valid = time.Time{}, false
@@ -152,10 +161,7 @@ func (m NullTime) reinterpret(driverTime time.Time) time.Time {
 }
 
 func (m NullTime) formatOutput() interface{} {
-	tz := m.timezone
-	if tz == nil {
-		tz = time.UTC
-	}
+	tz := m.outputLocation()
 	switch m.effectiveFormat() {
 	case TimeFormatRFC3339:
 		return m.val.In(tz).Format(time.RFC3339)
@@ -183,17 +189,13 @@ func (m NullTime) Value() (driver.Value, error) {
 	if !m.valid || m.val.IsZero() {
 		return nil, nil
 	}
-	tz := m.timezone
-	if tz == nil {
-		tz = time.UTC
-	}
 	switch v := m.formatOutput().(type) {
 	case string:
 		return v, nil
 	case int64:
 		return v, nil
 	}
-	return m.val.In(tz), nil
+	return m.val.In(m.outputLocation()), nil
 }
 
 func (m NullTime) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Fixes: #238

What changed: Modified internal/types/time.go so NullTime no longer forces UTC for human-facing outputs and driver.Value. Calls to .UTC() were replaced with .In(m.timezone) in formatOutput() (TimeFormatDatetime, TimeFormatDate, default) and in Value(). The TimeFormat enum and format strings remain unchanged. Unit tests that asserted UTC-formatted outputs were updated to expect timezone-consistent strings.

Why it changed: Reading DATETIME from MSSQL returned wall-clock times in the source timezone, but outputs were being formatted as UTC strings and stored in SQLite without timezone info. That caused the same wall-clock time to shift when read back as a local time (e.g., Asia/Shanghai). Formatting and driver.Value must use the source/configured timezone so stored human-readable strings and UI displays match the original MSSQL wall-clock time.

How to test: 1) Run unit tests: go test ./... and verify updated tests pass (codec/format and internal/types tests). 2) Integration check: read a DATETIME from MSSQL (e.g. 2026-04-11 00:00:00 in Asia/Shanghai), write to SQLite and assert the stored string is "2026-04-11 00:00:00" (not a UTC-shifted string). 3) Read that SQLite value back and confirm the UI or consumer displays the same wall-clock time (2026-04-11 00:00:00) with no timezone shift. 4) Verify MarshalJSON and other formatting helpers produce the same timezone-consistent output. Files changed: internal/types/time.go (primary); tests updated to reflect timezone-preserving formatting.