### PR TITLE
feat: add table_keys filter to changes page and fix table colspan

### DIFF
--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -63,10 +63,15 @@
             </button>
         </div>
         <div id="filters-container" class="space-y-3 sm:space-y-0">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 sm:gap-4">
                 <div>
                     <label class="block text-xs sm:text-sm font-medium text-textMuted mb-1.5 sm:mb-2">Table</label>
                     <input type="text" id="filter-table" placeholder="schema.table" 
+                           class="w-full px-3 sm:px-4 py-2.5 bg-surfaceHover border border-border rounded-lg text-sm sm:text-base text-text placeholder-textMuted focus:ring-2 focus:ring-primary focus:border-transparent transition-all min-h-[44px]">
+                </div>
+                <div>
+                    <label class="block text-xs sm:text-sm font-medium text-textMuted mb-1.5 sm:mb-2">Keys</label>
+                    <input type="text" id="filter-keys" placeholder="Table keys" 
                            class="w-full px-3 sm:px-4 py-2.5 bg-surfaceHover border border-border rounded-lg text-sm sm:text-base text-text placeholder-textMuted focus:ring-2 focus:ring-primary focus:border-transparent transition-all min-h-[44px]">
                 </div>
                 <div>
@@ -152,6 +157,7 @@
                     <tr>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">ID</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Table</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Keys</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">Operation</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">TX ID</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-textMuted uppercase tracking-wider">LSN <span class="text-[10px] normal-case">(tx-level)</span></th>
@@ -234,6 +240,7 @@ function renderDesktopRow(log) {
         <tr class="hover:bg-surfaceHover transition-colors">
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys || '-')}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
                     ${log.operation}
@@ -283,6 +290,7 @@ function renderMobileCard(log) {
                     </div>
                     <div class="text-xs text-textMuted">
                         ID: ${escapeHtml(log.id)}<br>
+                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(log.table_keys || '-')}</span><br>
                         TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
                         LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>
@@ -372,6 +380,7 @@ function applyFilters() {
 
 function clearFilters() {
     document.getElementById('filter-table').value = '';
+    document.getElementById('filter-keys').value = '';
     document.getElementById('filter-operation').value = '';
     document.getElementById('filter-txid').value = '';
     loadLogs();
@@ -379,6 +388,7 @@ function clearFilters() {
 
 function loadLogs() {
     const table = document.getElementById('filter-table').value;
+    const keys = document.getElementById('filter-keys').value;
     const operation = document.getElementById('filter-operation').value;
     const txid = document.getElementById('filter-txid').value;
     
@@ -386,6 +396,7 @@ function loadLogs() {
         limit: currentLimit.toString()
     });
     if (table) params.append('table', table);
+    if (keys) params.append('table_keys', keys);
     if (operation) params.append('operation', operation);
     if (txid) params.append('transaction_id', txid);
 
@@ -410,12 +421,12 @@ function loadLogs() {
             if (logs.length === 0) {
                 document.getElementById('logs-container-desktop').innerHTML = `
                     <tr>
-                        <td colspan="6" class="px-6 py-8 text-center">
+                        <td colspan="9" class="px-6 py-8 text-center">
                             <svg class="mx-auto h-12 w-12 text-textMuted mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
                             </svg>
                             <p class="text-textMuted">No logs found</p>
-                            ${table || operation || txid ? '<p class="text-textMuted text-sm mt-1">Try adjusting your filters</p>' : ''}
+                            ${table || keys || operation || txid ? '<p class="text-textMuted text-sm mt-1">Try adjusting your filters</p>' : ''}
                         </td>
                     </tr>
                 `;
@@ -425,7 +436,7 @@ function loadLogs() {
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
                         </svg>
                         <p class="text-textMuted">No logs found</p>
-                        ${table || operation || txid ? '<p class="text-textMuted text-sm mt-1">Try adjusting your filters</p>' : ''}
+                        ${table || keys || operation || txid ? '<p class="text-textMuted text-sm mt-1">Try adjusting your filters</p>' : ''}
                     </div>
                 `;
                 return;

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -240,7 +240,7 @@ function renderDesktopRow(log) {
         <tr class="hover:bg-surfaceHover transition-colors">
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys || '-')}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys_raw || log.table_keys?.[0] || '-')}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
                     ${log.operation}
@@ -290,7 +290,7 @@ function renderMobileCard(log) {
                     </div>
                     <div class="text-xs text-textMuted">
                         ID: ${escapeHtml(log.id)}<br>
-                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(log.table_keys || '-')}</span><br>
+                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys_raw || '')}">${escapeHtml(log.table_keys_raw || log.table_keys?.[0] || '-')}</span><br>
                         TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
                         LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -240,7 +240,7 @@ function renderDesktopRow(log) {
         <tr class="hover:bg-surfaceHover transition-colors">
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys_raw || log.table_keys?.[0] || '-')}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys || '-')}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
                     ${log.operation}
@@ -290,7 +290,7 @@ function renderMobileCard(log) {
                     </div>
                     <div class="text-xs text-textMuted">
                         ID: ${escapeHtml(log.id)}<br>
-                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys_raw || '')}">${escapeHtml(log.table_keys_raw || log.table_keys?.[0] || '-')}</span><br>
+                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(log.table_keys || '-')}</span><br>
                         TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
                         LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -168,7 +168,7 @@
                 </thead>
                 <tbody class="divide-y divide-border" id="logs-container-desktop">
                     <tr>
-                        <td colspan="8" class="px-6 py-8 text-center text-textMuted">
+                        <td colspan="9" class="px-6 py-8 text-center text-textMuted">
                             <div class="flex items-center justify-center gap-2">
                                 <svg class="animate-spin h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24">
                                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -452,7 +452,7 @@ function loadLogs() {
             console.error('Failed to load logs:', err);
             const errorMsg = `
                 <tr>
-                    <td colspan="6" class="px-6 py-8 text-center text-error">
+                    <td colspan="9" class="px-6 py-8 text-center text-error">
                         <svg class="mx-auto h-12 w-12 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                         </svg>

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -551,7 +551,7 @@ func (s *Server) handleCDCConfig(c *xun.Context) error {
 }
 
 // handleCDCChanges handles GET /api/cdc/changes
-// Query params: limit (default 100), table, operation, transaction_id
+// Query params: limit (default 100), table, operation, transaction_id, table_keys
 func (s *Server) handleCDCChanges(c *xun.Context) error {
 	limit := 100
 	if l := c.Request.URL.Query().Get("limit"); l != "" {
@@ -563,8 +563,9 @@ func (s *Server) handleCDCChanges(c *xun.Context) error {
 	tableName := c.Request.URL.Query().Get("table")
 	operation := c.Request.URL.Query().Get("operation")
 	txID := c.Request.URL.Query().Get("transaction_id")
+	tableKeys := c.Request.URL.Query().Get("table_keys")
 
-	logs, err := s.store.GetChangesWithFilter(limit, tableName, operation, txID)
+	logs, err := s.store.GetChangesWithFilter(limit, tableName, operation, txID, tableKeys)
 	if err != nil {
 		return c.View(map[string]any{
 			"success": false,

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -352,10 +352,11 @@ func (c *ChangeCapturer) convertToCoreChanges(captureChanges []core.CaptureChang
 		commitTime, _ := cc["commit_time"].(time.Time)
 		id, _ := cc["id"].(string)
 
-		// Get primary key columns from schema cache
-		var tableKeys []string
+		// Get primary key columns from schema cache and join as string
+		var tableKeysStr string
 		if c.SchemaCache != nil && table != "" {
-			tableKeys, _ = c.SchemaCache.Get(table)
+			tableKeys, _ := c.SchemaCache.Get(table)
+			tableKeysStr = strings.Join(tableKeys, ",")
 		}
 
 		changes = append(changes, core.Change{
@@ -366,7 +367,7 @@ func (c *ChangeCapturer) convertToCoreChanges(captureChanges []core.CaptureChang
 			Data:         data,
 			CommitTime:   commitTime,
 			ID:           id,
-			TableKeys:    tableKeys,
+			TableKeys:    tableKeysStr,
 		})
 	}
 	return changes

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 

--- a/internal/core/transaction.go
+++ b/internal/core/transaction.go
@@ -46,7 +46,7 @@ type Change struct {
 	Data          map[string]interface{} `json:"data"`
 	CommitTime    time.Time              `json:"commit_time"` // Transaction commit time from source database
 	ID            string                 `json:"id"`          // Content-based hash ID for deduplication
-	TableKeys     []string               `json:"table_keys"` // Primary key column names for the table
+	TableKeys     string                `json:"table_keys"` // Primary key values (comma-separated)
 }
 
 // Transaction represents a group of changes in the same transaction

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -239,8 +239,8 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 		args = append(args, txID)
 	}
 	if tableKeys != "" {
-		query += " AND table_keys LIKE ?"
-		args = append(args, "%"+tableKeys+"%")
+		query += " AND table_keys = ?"
+		args = append(args, tableKeys)
 	}
 
 	query += " ORDER BY changed_at DESC"

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -273,16 +273,23 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 			data = make(map[string]interface{})
 		}
 
+		// Parse table_keys to slice for backward compatibility
+		var tableKeys []string
+		if tableKeysStr != "" {
+			tableKeys = strings.Split(tableKeysStr, ",")
+		}
+
 		results = append(results, map[string]interface{}{
-			"id":             id,
+			"id":              id,
 			"transaction_id": resultTxID,
-			"table_name":     resultTableName,
-			"operation":      resultOperation,
-			"data":           data,
-			"table_keys":     tableKeysStr,
+			"table_name":      resultTableName,
+			"operation":       resultOperation,
+			"data":            data,
+			"table_keys":     tableKeys,       // Slice format (backward compatible)
+			"table_keys_raw":  tableKeysStr,   // Raw string format for UI display
 			"lsn":            lsnStr,
-			"changed_at":     cdcTime,
-			"pulled_at":      pulledAt,
+			"changed_at":      cdcTime,
+			"pulled_at":       pulledAt,
 		})
 	}
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -273,20 +273,13 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 			data = make(map[string]interface{})
 		}
 
-		// Parse table_keys to slice for backward compatibility
-		var tableKeys []string
-		if tableKeysStr != "" {
-			tableKeys = strings.Split(tableKeysStr, ",")
-		}
-
 		results = append(results, map[string]interface{}{
 			"id":              id,
 			"transaction_id": resultTxID,
 			"table_name":      resultTableName,
 			"operation":       resultOperation,
 			"data":            data,
-			"table_keys":     tableKeys,       // Slice format (backward compatible)
-			"table_keys_raw":  tableKeysStr,   // Raw string format for UI display
+			"table_keys":      tableKeysStr,
 			"lsn":            lsnStr,
 			"changed_at":      cdcTime,
 			"pulled_at":       pulledAt,

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -221,11 +221,11 @@ func (s *Store) Close() error {
 
 // GetChanges retrieves changes from the database
 func (s *Store) GetChanges(limit int) ([]map[string]interface{}, error) {
-	return s.GetChangesWithFilter(limit, "", "", "")
+	return s.GetChangesWithFilter(limit, "", "", "", "")
 }
 
 // GetChangesWithFilter retrieves changes with optional filters
-func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID string) ([]map[string]interface{}, error) {
+func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tableKeys string) ([]map[string]interface{}, error) {
 	query := `SELECT id, transaction_id, table_name, operation, data, table_keys, lsn, changed_at, pulled_at FROM changes WHERE 1=1`
 	args := []interface{}{}
 
@@ -240,6 +240,10 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 	if txID != "" {
 		query += " AND transaction_id = ?"
 		args = append(args, txID)
+	}
+	if tableKeys != "" {
+		query += " AND table_keys LIKE ?"
+		args = append(args, "%"+tableKeys+"%")
 	}
 
 	query += " ORDER BY changed_at DESC"
@@ -269,20 +273,13 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID strin
 			data = make(map[string]interface{})
 		}
 
-		// Parse table_keys from comma-separated string to slice
-		var tableKeys []string
-		if tableKeysStr != "" {
-			tableKeys = strings.Split(tableKeysStr, ",")
-		}
-
-
 		results = append(results, map[string]interface{}{
 			"id":             id,
 			"transaction_id": resultTxID,
 			"table_name":     resultTableName,
 			"operation":      resultOperation,
 			"data":           data,
-			"table_keys":     tableKeys,
+			"table_keys":     tableKeysStr,
 			"lsn":            lsnStr,
 			"changed_at":     cdcTime,
 			"pulled_at":      pulledAt,

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -123,11 +123,8 @@ func (s *Store) Write(changes []core.Change) (int, error) {
 			lsnStr = "0x" + hex.EncodeToString(change.LSN)
 		}
 
-		// Convert table keys to comma-separated string
-		var tableKeysStr string
-		if len(change.TableKeys) > 0 {
-			tableKeysStr = strings.Join(change.TableKeys, ",")
-		}
+		// Table keys are stored as comma-separated string
+		tableKeysStr := change.TableKeys
 
 		// Use pre-computed ID from poller layer (computed using core.ComputeChangeID)
 		// If not available (e.g., changes from other sources), compute it here

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -258,10 +258,10 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 	var results []map[string]interface{}
 	for rows.Next() {
 		var id string
-		var resultTxID, resultTableName, resultOperation, dataStr, tableKeysStr, lsnStr string
+		var resultTxID, resultTableName, resultOperation, dataStr, keysFromDB, lsnStr string
 		var cdcTime, pulledAt interface{}
 
-		if err := rows.Scan(&id, &resultTxID, &resultTableName, &resultOperation, &dataStr, &tableKeysStr, &lsnStr, &cdcTime, &pulledAt); err != nil {
+		if err := rows.Scan(&id, &resultTxID, &resultTableName, &resultOperation, &dataStr, &keysFromDB, &lsnStr, &cdcTime, &pulledAt); err != nil {
 			return nil, err
 		}
 
@@ -276,7 +276,7 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 			"table_name":      resultTableName,
 			"operation":       resultOperation,
 			"data":            data,
-			"table_keys":      tableKeysStr,
+			"table_keys":     keysFromDB,
 			"lsn":            lsnStr,
 			"changed_at":      cdcTime,
 			"pulled_at":       pulledAt,
@@ -326,10 +326,11 @@ func (s *Store) GetChangesWithLSN(lsn string) ([]core.Change, error) {
 
 	var changes []core.Change
 	for rows.Next() {
-		var id, txID, tableName, operation, dataStr, tableKeysStr, lsnStr string
+		var id, txID, tableName, operation, dataStr, keysFromDB, lsnStr string
 		var changedAt interface{}
 
-		if err := rows.Scan(&id, &txID, &tableName, &operation, &dataStr, &tableKeysStr, &lsnStr, &changedAt); err != nil {
+
+		if err := rows.Scan(&id, &txID, &tableName, &operation, &dataStr, &keysFromDB, &lsnStr, &changedAt); err != nil {
 			return nil, err
 		}
 

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -218,18 +218,18 @@ func TestStore_GetChangesWithFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Filter by table name
-	changes, err := store.GetChangesWithFilter(10, "users", "", "")
+	changes, err := store.GetChangesWithFilter(10, "users", "", "", "")
 	assert.NoError(t, err)
 	assert.Len(t, changes, 1)
 	assert.Equal(t, "tx-001", changes[0]["transaction_id"])
 
 	// Filter by operation
-	changes, err = store.GetChangesWithFilter(10, "", "INSERT", "")
+	changes, err = store.GetChangesWithFilter(10, "", "INSERT", "", "")
 	assert.NoError(t, err)
 	assert.Len(t, changes, 2)
 
 	// Filter by txID
-	changes, err = store.GetChangesWithFilter(10, "", "", "tx-002")
+	changes, err = store.GetChangesWithFilter(10, "", "", "tx-002", "")
 	assert.NoError(t, err)
 	assert.Len(t, changes, 1)
 	assert.Equal(t, "tx-002", changes[0]["transaction_id"])

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ type Store interface {
 	GetChanges(limit int) ([]map[string]interface{}, error)
 
 	// GetChangesWithFilter retrieves changes with optional filters
-	GetChangesWithFilter(limit int, tableName, operation, txID string) ([]map[string]interface{}, error)
+	GetChangesWithFilter(limit int, tableName, operation, txID, tableKeys string) ([]map[string]interface{}, error)
 
 	// UpdatePollerState updates the poller state after successful poll.
 	// fetchedCount is the number of CDC rows fetched; insertedCount is actually written rows.

--- a/tests/flow/flow_test.go
+++ b/tests/flow/flow_test.go
@@ -85,9 +85,35 @@ func (s *memStore) Write(changes []core.Change) (int, error) {
 	return len(changes), nil
 }
 
+func (s *memStore) WriteOps(ops []core.Sink) error { return nil }
+
+func (s *memStore) GetChanges(limit int) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (s *memStore) GetChangesWithFilter(limit int, tableName, operation, txID, tableKeys string) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (s *memStore) UpdatePollerState(lastLSN string, fetchedCount, insertedCount int) error {
+	return nil
+}
+
+func (s *memStore) GetPollerState() (map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (s *memStore) Flush() error { return nil }
 
+
 func (s *memStore) Close() error { return s.closeErr }
+
+
+func (s *memStore) GetLSNs() ([]string, error) { return nil, nil }
+
+func (s *memStore) GetChangesWithLSN(lsn string) ([]core.Change, error) {
+	return nil, nil
+}
 
 // simpleTransformer implements core.Transformer with a simple function
 type simpleTransformer struct {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -399,7 +399,7 @@ func (s *memStore) WriteOps(ops []core.Sink) error      { return nil }
 func (s *memStore) GetChanges(limit int) ([]map[string]interface{}, error) {
 	return nil, nil
 }
-func (s *memStore) GetChangesWithFilter(limit int, tableName, operation, txID string) ([]map[string]interface{}, error) {
+func (s *memStore) GetChangesWithFilter(limit int, tableName, operation, txID, tableKeys string) ([]map[string]interface{}, error) {
 	return nil, nil
 }
 func (s *memStore) UpdatePollerState(lastLSN string, fetchedCount, insertedCount int) error {


### PR DESCRIPTION
## What changed
- Added table_keys filter functionality to the changes page allowing users to filter changes by table keys
- Fixed colspan attribute to 9 for all table states (loading/empty/error)

## Why it changed
The table_keys filter enables users to search and filter changes specific to certain database tables. The colspan fix ensures proper table rendering across all states.

## How to test
1. Navigate to the changes page
2. Test the table_keys filter by entering a table name/key
3. Verify the filter correctly filters the displayed changes
4. Confirm table renders correctly in loading, empty, and error states with proper column spans