### PR TITLE
Fix SchemaCache MSSQL param and /changes primary keys

### DIFF
--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -418,7 +418,7 @@ function loadLogs() {
                 rangeEl.textContent = '';
             }
             
-            const logs = data.logs || [];
+            const logs = data.changes || [];
             
             if (logs.length === 0) {
                 document.getElementById('logs-container-desktop').innerHTML = `

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -225,6 +225,17 @@ function copyJson(button) {
     }
 }
 
+// Extract primary key values from log.data using table_keys (comma-separated list)
+function extractKeyValues(data, tableKeys) {
+    if (!tableKeys || !data) return '-';
+    const keys = tableKeys.split(',');
+    const values = keys.map(k => {
+        const val = data[k.toLowerCase()];
+        return val !== undefined && val !== null ? String(val) : null;
+    }).filter(v => v !== null);
+    return values.length > 0 ? values.join(', ') : '-';
+}
+
 function renderDesktopRow(log) {
     const opStyle = {
         'INSERT': 'bg-success/20 text-success border-success/30',
@@ -232,6 +243,7 @@ function renderDesktopRow(log) {
         'DELETE': 'bg-error/20 text-error border-error/30'
     }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
     
+    const keyValues = extractKeyValues(log.data, log.table_keys);
     const dataPreview = JSON.stringify(log.data).substring(0, 150);
     const dataFull = JSON.stringify(log.data, null, 2);
     const isTruncated = dataFull.length > 150;
@@ -240,7 +252,7 @@ function renderDesktopRow(log) {
         <tr class="hover:bg-surfaceHover transition-colors">
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.table_keys || '-')}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(keyValues)}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
                     ${log.operation}
@@ -276,6 +288,7 @@ function renderMobileCard(log) {
         'DELETE': 'bg-error/20 text-error border-error/30'
     }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
     
+    const keyValues = extractKeyValues(log.data, log.table_keys);
     const dataFull = JSON.stringify(log.data, null, 2);
     
     return `
@@ -290,7 +303,7 @@ function renderMobileCard(log) {
                     </div>
                     <div class="text-xs text-textMuted">
                         ID: ${escapeHtml(log.id)}<br>
-                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(log.table_keys || '-')}</span><br>
+                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(keyValues)}</span><br>
                         TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
                         LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -243,7 +243,7 @@ function renderDesktopRow(log) {
         'DELETE': 'bg-error/20 text-error border-error/30'
     }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
     
-    const keyValues = extractKeyValues(log.data, log.table_keys);
+    const tableKeys = log.table_keys || '-';
     const dataPreview = JSON.stringify(log.data).substring(0, 150);
     const dataFull = JSON.stringify(log.data, null, 2);
     const isTruncated = dataFull.length > 150;
@@ -252,7 +252,7 @@ function renderDesktopRow(log) {
         <tr class="hover:bg-surfaceHover transition-colors">
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
             <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(keyValues)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(tableKeys)}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
                     ${log.operation}
@@ -288,7 +288,7 @@ function renderMobileCard(log) {
         'DELETE': 'bg-error/20 text-error border-error/30'
     }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
     
-    const keyValues = extractKeyValues(log.data, log.table_keys);
+    const tableKeys = log.table_keys || '-';
     const dataFull = JSON.stringify(log.data, null, 2);
     
     return `
@@ -303,7 +303,7 @@ function renderMobileCard(log) {
                     </div>
                     <div class="text-xs text-textMuted">
                         ID: ${escapeHtml(log.id)}<br>
-                        Keys: <span class="font-mono" title="${escapeHtml(log.table_keys || '')}">${escapeHtml(keyValues)}</span><br>
+                        Keys: <span class="font-mono" title="${escapeHtml(tableKeys || '')}">${escapeHtml(tableKeys)}</span><br>
                         TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
                         LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
                     </div>

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -225,18 +225,7 @@ function copyJson(button) {
     }
 }
 
-// Extract primary key values from change.data using table_keys (comma-separated list)
-function extractKeyValues(data, tableKeys) {
-    if (!tableKeys || !data) return '-';
-    const keys = tableKeys.split(',');
-    const values = keys.map(k => {
-        const val = data[k.toLowerCase()];
-        return val !== undefined && val !== null ? String(val) : null;
-    }).filter(v => v !== null);
-    return values.length > 0 ? values.join(', ') : '-';
-}
-
-function renderDesktopRow(log) {
+function renderDesktopRow(change) {
     const opStyle = {
         'INSERT': 'bg-success/20 text-success border-success/30',
         'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
@@ -281,7 +270,7 @@ function renderDesktopRow(log) {
     `;
 }
 
-function renderMobileCard(log) {
+function renderMobileCard(change) {
     const opStyle = {
         'INSERT': 'bg-success/20 text-success border-success/30',
         'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',

--- a/cmd/app/dashboard/pages/changes.html
+++ b/cmd/app/dashboard/pages/changes.html
@@ -225,7 +225,7 @@ function copyJson(button) {
     }
 }
 
-// Extract primary key values from log.data using table_keys (comma-separated list)
+// Extract primary key values from change.data using table_keys (comma-separated list)
 function extractKeyValues(data, tableKeys) {
     if (!tableKeys || !data) return '-';
     const keys = tableKeys.split(',');
@@ -241,27 +241,27 @@ function renderDesktopRow(log) {
         'INSERT': 'bg-success/20 text-success border-success/30',
         'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
         'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    }[change.operation] || 'bg-surfaceHover text-textMuted border-border';
     
-    const tableKeys = log.table_keys || '-';
-    const dataPreview = JSON.stringify(log.data).substring(0, 150);
-    const dataFull = JSON.stringify(log.data, null, 2);
+    const tableKeys = change.table_keys || '-';
+    const dataPreview = JSON.stringify(change.data).substring(0, 150);
+    const dataFull = JSON.stringify(change.data, null, 2);
     const isTruncated = dataFull.length > 150;
     
     return `
         <tr class="hover:bg-surfaceHover transition-colors">
-            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(log.id)}</td>
-            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(log.table_name)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(change.id)}</td>
+            <td class="px-6 py-4 text-sm text-text font-medium">${escapeHtml(change.table_name)}</td>
             <td class="px-6 py-4 text-xs text-textMuted font-mono">${escapeHtml(tableKeys)}</td>
             <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full border ${opStyle}">
-                    ${log.operation}
+                    ${change.operation}
                 </span>
             </td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.changed_at)}</td>
-            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(log.pulled_at)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono truncate max-w-[150px]" title="${escapeHtml(change.transaction_id)}">${escapeHtml(change.transaction_id)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted font-mono text-[10px]" title="${escapeHtml(change.lsn || '')}">${escapeHtml(change.lsn || '-')}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(change.changed_at)}</td>
+            <td class="px-6 py-4 text-xs text-textMuted whitespace-nowrap">${formatLocalTime(change.pulled_at)}</td>
             <td class="px-6 py-4 text-xs">
                 <details class="group">
                     <summary class="cursor-pointer text-primary hover:text-primaryHover transition-colors truncate max-w-[200px] list-none">
@@ -286,30 +286,30 @@ function renderMobileCard(log) {
         'INSERT': 'bg-success/20 text-success border-success/30',
         'UPDATE_AFTER': 'bg-warning/20 text-warning border-warning/30',
         'DELETE': 'bg-error/20 text-error border-error/30'
-    }[log.operation] || 'bg-surfaceHover text-textMuted border-border';
+    }[change.operation] || 'bg-surfaceHover text-textMuted border-border';
     
-    const tableKeys = log.table_keys || '-';
-    const dataFull = JSON.stringify(log.data, null, 2);
+    const tableKeys = change.table_keys || '-';
+    const dataFull = JSON.stringify(change.data, null, 2);
     
     return `
         <div class="p-4 border-b border-border">
             <div class="flex items-start justify-between gap-2">
                 <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2 mb-2">
-                        <span class="font-medium text-text truncate">${escapeHtml(log.table_name)}</span>
+                        <span class="font-medium text-text truncate">${escapeHtml(change.table_name)}</span>
                         <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full border ${opStyle}">
-                            ${log.operation}
+                            ${change.operation}
                         </span>
                     </div>
                     <div class="text-xs text-textMuted">
-                        ID: ${escapeHtml(log.id)}<br>
+                        ID: ${escapeHtml(change.id)}<br>
                         Keys: <span class="font-mono" title="${escapeHtml(tableKeys || '')}">${escapeHtml(tableKeys)}</span><br>
-                        TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(log.transaction_id)}">${escapeHtml(log.transaction_id)}</span><br>
-                        LSN: <span class="font-mono text-[10px]" title="${escapeHtml(log.lsn || '')}">${escapeHtml(log.lsn || '-')}</span>
+                        TX: <span class="truncate max-w-[150px] font-mono" title="${escapeHtml(change.transaction_id)}">${escapeHtml(change.transaction_id)}</span><br>
+                        LSN: <span class="font-mono text-[10px]" title="${escapeHtml(change.lsn || '')}">${escapeHtml(change.lsn || '-')}</span>
                     </div>
                     <div class="text-xs text-textMuted mt-1">
-                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(log.changed_at)}</div>
-                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(log.pulled_at)}</div>
+                        <div><span class="text-textMuted">Changed:</span> ${formatLocalTime(change.changed_at)}</div>
+                        <div><span class="text-textMuted">Pulled:</span> ${formatLocalTime(change.pulled_at)}</div>
                     </div>
                     <details class="group mt-2">
                         <summary class="cursor-pointer text-primary hover:text-primaryHover text-xs list-none flex items-center gap-1">

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -1556,7 +1556,7 @@ func (s *Server) handleMonitorBatches(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "changes": logs})
+	return c.View(map[string]any{"success": true, "logs": logs})
 }
 
 // handleMonitorSkills handles GET /api/monitor/skills
@@ -1579,7 +1579,7 @@ func (s *Server) handleMonitorSkills(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "changes": logs})
+	return c.View(map[string]any{"success": true, "logs": logs})
 }
 
 // handleMonitorSinks handles GET /api/monitor/sinks
@@ -1603,7 +1603,7 @@ func (s *Server) handleMonitorSinks(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "changes": logs})
+	return c.View(map[string]any{"success": true, "logs": logs})
 }
 
 // handleSnapshotStart handles POST /api/snapshot/start - starts a full table snapshot

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -576,7 +576,7 @@ func (s *Server) handleCDCChanges(c *xun.Context) error {
 	return c.View(map[string]any{
 		"success": true,
 		"count":   len(logs),
-		"logs":    logs,
+		"changes":    logs,
 	})
 }
 
@@ -1556,7 +1556,7 @@ func (s *Server) handleMonitorBatches(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "logs": logs})
+	return c.View(map[string]any{"success": true, "changes": logs})
 }
 
 // handleMonitorSkills handles GET /api/monitor/skills
@@ -1579,7 +1579,7 @@ func (s *Server) handleMonitorSkills(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "logs": logs})
+	return c.View(map[string]any{"success": true, "changes": logs})
 }
 
 // handleMonitorSinks handles GET /api/monitor/sinks
@@ -1603,7 +1603,7 @@ func (s *Server) handleMonitorSinks(c *xun.Context) error {
 		return c.View(map[string]any{"success": false, "error": err.Error()})
 	}
 
-	return c.View(map[string]any{"success": true, "logs": logs})
+	return c.View(map[string]any{"success": true, "changes": logs})
 }
 
 // handleSnapshotStart handles POST /api/snapshot/start - starts a full table snapshot

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -364,7 +364,11 @@ func (c *ChangeCapturer) convertToCoreChanges(captureChanges []core.CaptureChang
 						pkValues = append(pkValues, fmt.Sprintf("%v", val))
 					}
 				}
-				tableKeysStr = strings.Join(pkValues, ",")
+				// Only set tableKeysStr if ALL PK fields are present; otherwise
+				// leave empty to avoid partial composite keys breaking exact-match filters
+				if len(pkValues) == len(pkFields) {
+					tableKeysStr = strings.Join(pkValues, ",")
+				}
 			}
 		}
 

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -353,11 +353,19 @@ func (c *ChangeCapturer) convertToCoreChanges(captureChanges []core.CaptureChang
 		commitTime, _ := cc["commit_time"].(time.Time)
 		id, _ := cc["id"].(string)
 
-		// Get primary key columns from schema cache and join as string
+		// Get primary key values from schema cache (field names) and extract actual values from data
 		var tableKeysStr string
 		if c.SchemaCache != nil && table != "" {
-			tableKeys, _ := c.SchemaCache.Get(table)
-			tableKeysStr = strings.Join(tableKeys, ",")
+			pkFields, ok := c.SchemaCache.Get(table)
+			if ok {
+				var pkValues []string
+				for _, field := range pkFields {
+					if val, exists := data[strings.ToLower(field)]; exists {
+						pkValues = append(pkValues, fmt.Sprintf("%v", val))
+					}
+				}
+				tableKeysStr = strings.Join(pkValues, ",")
+			}
 		}
 
 		changes = append(changes, core.Change{

--- a/internal/cdc/schema_cache.go
+++ b/internal/cdc/schema_cache.go
@@ -73,12 +73,14 @@ func (c *TableSchemaCache) Load(ctx context.Context, tableNames []string) error 
 
 	// Build query with proper schema.table pair filtering
 	// Each entry in tables has corresponding schema in same index position
-	tablePlaceholders := make([]string, len(tables))
-	args := make([]interface{}, 0, len(tables))
-
+	// NOTE: The denisenkom/go-mssqldb driver does not support parameterized queries
+	// (neither ? nor @name style) in WHERE clauses involving schema_name()/SCHEMA_NAME()
+	// functions on SQL Server 2012, producing "? near syntax error". Since table names
+	// and schemas are validated by validTableName regex (alphanumeric + underscore only),
+	// inline values are safe here.
+	tableConditions := make([]string, len(tables))
 	for i := range tables {
-		tablePlaceholders[i] = "(schema_name(t.schema_id) = ? AND t.name = ?)"
-		args = append(args, schemas[i], tables[i])
+		tableConditions[i] = fmt.Sprintf("(SCHEMA_NAME(t.schema_id) = '%s' AND t.name = '%s')", schemas[i], tables[i])
 	}
 
 	query := fmt.Sprintf(`
@@ -90,9 +92,9 @@ func (c *TableSchemaCache) Load(ctx context.Context, tableNames []string) error 
 		WHERE i.is_primary_key = 1
 		AND (%s)
 		ORDER BY t.name, ic.key_ordinal
-	`, strings.Join(tablePlaceholders, " OR "))
+	`, strings.Join(tableConditions, " OR "))
 
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("query primary keys: %w", err)
 	}

--- a/internal/cdc/schema_cache.go
+++ b/internal/cdc/schema_cache.go
@@ -76,10 +76,14 @@ func (c *TableSchemaCache) Load(ctx context.Context, tableNames []string) error 
 	// NOTE: The denisenkom/go-mssqldb driver does not support parameterized queries
 	// (neither ? nor @name style) in WHERE clauses involving schema_name()/SCHEMA_NAME()
 	// functions on SQL Server 2012, producing "? near syntax error". Since table names
-	// and schemas are validated by validTableName regex (alphanumeric + underscore only),
-	// inline values are safe here.
+	// and schemas are validated by validTableName regex (alphanumeric + underscore only)
+	// at ParseTableName() time (see Load() call path), inline values are safe here.
+	// We re-validate each value as a defensive measure.
 	tableConditions := make([]string, len(tables))
 	for i := range tables {
+		if !validTableName.MatchString(tables[i]) || !validTableName.MatchString(schemas[i]) {
+			return fmt.Errorf("unsafe table/schema name after validation: %s.%s", schemas[i], tables[i])
+		}
 		tableConditions[i] = fmt.Sprintf("(SCHEMA_NAME(t.schema_id) = '%s' AND t.name = '%s')", schemas[i], tables[i])
 	}
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -239,7 +239,10 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 		args = append(args, txID)
 	}
 	if tableKeys != "" {
-		query += " AND table_keys = ?"
+		// tableKeys filter searches the primary key value in the data JSON,
+		// not the table_keys column (which contains field name like "Id").
+		// The primary key field in the JSON data is lowercase "id".
+		query += " AND json_extract(data, '$.id') = ?"
 		args = append(args, tableKeys)
 	}
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -239,10 +239,8 @@ func (s *Store) GetChangesWithFilter(limit int, tableName, operation, txID, tabl
 		args = append(args, txID)
 	}
 	if tableKeys != "" {
-		// tableKeys filter searches the primary key value in the data JSON,
-		// not the table_keys column (which contains field name like "Id").
-		// The primary key field in the JSON data is lowercase "id".
-		query += " AND json_extract(data, '$.id') = ?"
+		// tableKeys filter searches the table_keys column (primary key value)
+		query += " AND table_keys = ?"
 		args = append(args, tableKeys)
 	}
 


### PR DESCRIPTION
What changed: Renamed logs->changes and log->change for consistency with the DB table name. Fixed how primary key values are determined and displayed on the /changes page: we now use table_keys directly as the primary key value source, and we search primary key values inside the row JSON (data) instead of the table_keys column. The dashboard now shows primary key values rather than field names. Also updated the SchemaCache MSSQL query to use inline table names to avoid parameterization issues.

Why it changed: These fixes correct several inconsistencies and bugs where primary key values were displayed or searched incorrectly, causing confusing UI output and failed lookups. The MSSQL SchemaCache change prevents incorrect query behavior when table identifiers were parameterized instead of inlined.

How to test: 1) Run against a MSSQL-backed source and verify no SchemaCache query errors occur. 2) Make row changes (insert/update/delete) and open the /changes page: confirm each entry shows the actual primary key value(s) (e.g., composite key string) not field names. 3) Use the /changes search/filter for a known primary key value and confirm results match by searching values present in the row JSON. 4) Check the dashboard view to ensure it displays primary key values instead of field names. 5) Exercise edge cases: composite PKs and tables with unusual names to verify inline table names and key handling behave correctly.