### PR TITLE
fix: upgrade cnlangzi/sqlite to v0.0.5 remove _query_only and mmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/bytedance/sonic v1.15.0
-	github.com/cnlangzi/sqlite v0.0.4
+	github.com/cnlangzi/sqlite v0.0.5
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiD
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cnlangzi/sqlite v0.0.4 h1:COPJi/UeFY973LKR5D8n8pG+xt8wOrHJyqHisxDtNY8=
-github.com/cnlangzi/sqlite v0.0.4/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
+github.com/cnlangzi/sqlite v0.0.5 h1:H63klh9H5tlH69oixaC89JzJnoCmpc4ufrGBfihxBwU=
+github.com/cnlangzi/sqlite v0.0.5/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

Removes `_query_only=true` and `mmap_size` from readerDSN() to fix mmap not being refreshed after WAL checkpoint, which caused Reader to return stale/phantom data.

## Root Cause

When Reader opens a DB with `_query_only=true`:
1. SQLite skips SHM coordination (shared memory header)
2. mmap stays bound to the old db file state even after WAL checkpoint
3. Any deleted/updated rows in WAL show up as ghost data via stale mmap

## Fix

- Upgraded `github.com/cnlangzi/sqlite` from v0.0.4 to v0.0.5
- v0.0.5 removes `_query_only=true` and `_pragma mmap_size()` from reader DSN
- Reader now uses standard SQLite shared memory coordination, properly syncing mmap on checkpoint

## Verification

Before fix (v0.0.4):
- Reader API: `SELECT COUNT(*) FROM Cost` → 13603 ❌ (phantom row)
- Direct sqlite3: 13602 ✅

After fix (v0.0.5):
- Reader API: 13602 ✅
- Direct sqlite3: 13602 ✅

Fixes: https://github.com/cnlangzi/sqlite/issues/6