### PR TITLE
fix: ensure poller state updates on every CDC poll cycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/bytedance/sonic v1.15.0
-	github.com/cnlangzi/sqlite v0.0.4
+	github.com/cnlangzi/sqlite v0.0.5
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiD
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cnlangzi/sqlite v0.0.4 h1:COPJi/UeFY973LKR5D8n8pG+xt8wOrHJyqHisxDtNY8=
-github.com/cnlangzi/sqlite v0.0.4/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
+github.com/cnlangzi/sqlite v0.0.5 h1:H63klh9H5tlH69oixaC89JzJnoCmpc4ufrGBfihxBwU=
+github.com/cnlangzi/sqlite v0.0.5/go.mod h1:ZFzkDD6M7EOGBfPtrD4lMe/0nYrOr1bVfOK0o3wEVbs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -170,7 +170,7 @@ func (c *ChangeCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 
 	// Write changes to cdc.db store
 	var insertedCount int
-	var lastLSN string
+	lastLSN := hex.EncodeToString(globalMaxLSN)
 	if c.Store != nil && len(allChanges) > 0 {
 		coreChanges := c.convertToCoreChanges(allChanges)
 		n, err := c.Store.Write(coreChanges)
@@ -180,15 +180,17 @@ func (c *ChangeCapturer) Fetch(ctx context.Context) *core.CaptureResult {
 		}
 		insertedCount = n
 
-		// Update poller state on every poll cycle to keep last_poll_time current
-		lastLSN = hex.EncodeToString(globalMaxLSN)
-		if err := c.Store.UpdatePollerState(lastLSN, len(allChanges), insertedCount); err != nil {
-			slog.Warn("ChangeCapturer: failed to update poller state", "error", err)
-			return &core.CaptureResult{NextCapturer: core.CapturerCDC}
-		}
-
 		if err := c.Store.Flush(); err != nil {
 			slog.Warn("ChangeCapturer: failed to flush store", "error", err)
+			return &core.CaptureResult{NextCapturer: core.CapturerCDC}
+		}
+	}
+
+	// Always update poller state on every poll cycle for liveness monitoring.
+	// This updates last_poll_time even when there are no changes (idle state).
+	if c.Store != nil {
+		if err := c.Store.UpdatePollerState(lastLSN, len(allChanges), insertedCount); err != nil {
+			slog.Warn("ChangeCapturer: failed to update poller state", "error", err)
 			return &core.CaptureResult{NextCapturer: core.CapturerCDC}
 		}
 	}


### PR DESCRIPTION
## Summary

Ensure `UpdatePollerState` is called on every poll cycle, even when there are no CDC changes. This keeps `last_poll_time` current for liveness monitoring.

## Root Cause

Previously, `UpdatePollerState` was only called when `len(allChanges) > 0`. During idle periods with no CDC changes, the poller state (including `last_poll_time`) was never updated, making it impossible to distinguish between a dead poller and an active one with no changes.

## Fix

Moved `UpdatePollerState` outside the `len(allChanges) > 0` block so it updates on every poll cycle, regardless of whether changes were found.

Before:


After:
