### PR TITLE
fix(cdc): deterministic change IDs for net_changes (no seqval)

### DIFF
--- a/internal/cdc/capturer.go
+++ b/internal/cdc/capturer.go
@@ -377,6 +377,16 @@ func (c *ChangeCapturer) convertToCoreChanges(captureChanges []core.CaptureChang
 			}
 		}
 
+		// fn_cdc_get_net_changes_* does not include __$seqval, so ComputeNativeID
+		// degenerates to "{lsn}::{op}" and collides across rows sharing the same
+		// transaction LSN and operation.  Re-compute the ID using table name +
+		// primary key values when they are available; including the table name
+		// prevents cross-table collisions when the same transaction touches
+		// multiple tables whose PK values happen to be equal.
+		if tableKeysStr != "" {
+			id = hex.EncodeToString(lsn) + ":" + table + ":" + tableKeysStr + ":" + strconv.Itoa(opVal)
+		}
+
 		changes = append(changes, core.Change{
 			Table:         table,
 			TransactionID: txID,


### PR DESCRIPTION
## Summary

SQL Server `fn_cdc_get_net_changes_*` does **not** return `__`. Our previous native ID `hex(lsn):hex(seqval):op` therefore degraded to `hex(lsn)::op`, collapsing multiple rows in the same transaction LSN to one primary key and causing `INSERT OR IGNORE` on SQLite to drop most rows.

After fixing PK-based IDs, a second issue appeared: `lsn:pk:op` can still collide **across tables** when one transaction updates multiple tables whose primary key values happen to match (e.g. same numeric `Id`).

## Fix

When all PK columns are resolved from `SchemaCache`, set:

```
id = hex(lsn) + ':' + tableName + ':' + pkValues + ':' + op
```

This keeps `net_changes` (no UPDATE_BEFORE noise) while making stored IDs unique per captured row.

## Validation

- Local dev run: `total_inserted` matched `total_changes` after the change (Cost / CostExd / Costitem row counts aligned with MSSQL net_changes).

Made with [Cursor](https://cursor.com)