### PR TITLE
Add snapshot phase timing display to dashboard UI

### DIFF
--- a/cmd/app/dashboard/pages/snapshot.html
+++ b/cmd/app/dashboard/pages/snapshot.html
@@ -54,6 +54,33 @@
         <p id="run-error" class="hidden mt-1 text-sm text-error"></p>
     </div>
 
+    <!-- Phase Timing Cards (shown for both running and completed) -->
+    <div id="panel-timing" class="hidden bg-surface rounded-xl shadow-lg p-4 sm:p-6 border border-border">
+        <h3 class="text-base sm:text-lg font-semibold text-text mb-3 sm:mb-4">Phase Timing</h3>
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3 sm:gap-4">
+            <div class="p-3 sm:p-4 rounded-xl bg-surfaceHover border border-border">
+                <p class="text-textMuted text-xs sm:text-sm mb-1">Read</p>
+                <p id="run-read-ms" class="text-sm font-bold text-text font-mono">—</p>
+            </div>
+            <div class="p-3 sm:p-4 rounded-xl bg-surfaceHover border border-border">
+                <p class="text-textMuted text-xs sm:text-sm mb-1">Build</p>
+                <p id="run-build-ms" class="text-sm font-bold text-text font-mono">—</p>
+            </div>
+            <div class="p-3 sm:p-4 rounded-xl bg-surfaceHover border border-border">
+                <p class="text-textMuted text-xs sm:text-sm mb-1">Transform</p>
+                <p id="run-transform-ms" class="text-sm font-bold text-text font-mono">—</p>
+            </div>
+            <div class="p-3 sm:p-4 rounded-xl bg-surfaceHover border border-border">
+                <p class="text-textMuted text-xs sm:text-sm mb-1">Write</p>
+                <p id="run-write-ms" class="text-sm font-bold text-text font-mono">—</p>
+            </div>
+            <div class="p-3 sm:p-4 rounded-xl bg-surfaceHover border border-border">
+                <p class="text-textMuted text-xs sm:text-sm mb-1">Read Rows/s</p>
+                <p id="run-rows-per-sec" class="text-sm font-bold text-text font-mono">—</p>
+            </div>
+        </div>
+    </div>
+
     <!-- Completion Summary Panel -->
     <div id="panel-summary" class="hidden bg-surface rounded-xl shadow-lg p-4 sm:p-6 border border-success/30">
         <h3 class="text-base sm:text-lg font-semibold text-text mb-3 sm:mb-4 flex items-center gap-2">
@@ -266,12 +293,27 @@ function updateElapsed() {
     document.getElementById('run-elapsed').textContent = fmtDuration(secs);
 }
 
-function showRunningPanel() { document.getElementById('panel-running').classList.remove('hidden'); }
-function hideRunningPanel() { document.getElementById('panel-running').classList.add('hidden'); }
-function hideSummaryPanel() { document.getElementById('panel-summary').classList.add('hidden'); }
+function showRunningPanel() {
+    document.getElementById('panel-running').classList.remove('hidden');
+    showTimingPanel();
+}
+function hideRunningPanel() {
+    document.getElementById('panel-running').classList.add('hidden');
+    document.getElementById('panel-timing').classList.add('hidden');
+}
+
+function hideSummaryPanel() {
+    document.getElementById('panel-summary').classList.add('hidden');
+    document.getElementById('panel-timing').classList.add('hidden');
+}
+
+function showTimingPanel() {
+    document.getElementById('panel-timing').classList.remove('hidden');
+}
 
 function showSummaryPanel(data) {
     document.getElementById('panel-summary').classList.remove('hidden');
+    showTimingPanel();
     document.getElementById('sum-tables').textContent = (data.processed || 0) + ' / ' + (data.total || 0);
     document.getElementById('sum-rows').textContent = fmtNum(data.read_rows || 0);
     if (data.start_time) {
@@ -298,9 +340,15 @@ function updateRunningUI(data) {
     document.getElementById('run-total-rows').textContent = fmtNum(totalRows);
     document.getElementById('run-current-table').textContent = data.current_table || '—';
 
-    var pct = totalRows > 0 ? Math.min(100, Math.round((readRows / totalRows) * 100)) : 0;
+    var pct = totalRows > 0 ? Math.round((readRows / totalRows) * 100) : 0;
     document.getElementById('run-progress-bar').style.width = pct + '%';
     document.getElementById('run-pct').textContent = pct + '%';
+
+    document.getElementById('run-read-ms').textContent = fmtMs(data.read_ms);
+    document.getElementById('run-build-ms').textContent = fmtMs(data.build_ms);
+    document.getElementById('run-transform-ms').textContent = fmtMs(data.transform_ms);
+    document.getElementById('run-write-ms').textContent = fmtMs(data.write_ms);
+    document.getElementById('run-rows-per-sec').textContent = data.read_rows_per_sec ? data.read_rows_per_sec.toFixed(1) + ' r/s' : '—';
 
     var errEl = document.getElementById('run-error');
     if (data.error) { errEl.textContent = 'Error: ' + data.error; errEl.classList.remove('hidden'); }
@@ -334,6 +382,8 @@ function updateTableProgress(tables, state, currentTable) {
             rowBg = 'bg-surfaceHover border-border'; barColor = 'bg-border'; icon = dbIcon;
         }
 
+        var timingLabel = '<span class="text-xs text-textMuted font-mono flex-shrink-0">R:' + fmtMs(t.read_ms) + ' B:' + fmtMs(t.build_ms) + ' T:' + fmtMs(t.transform_ms) + ' W:' + fmtMs(t.write_ms) + '</span>';
+
         var miniBar = hasTotal
             ? '<div class="w-24 bg-border rounded-full h-1.5 flex-shrink-0"><div class="' + barColor + ' h-1.5 rounded-full transition-all duration-300" style="width:' + pct + '%"></div></div>'
             : '';
@@ -342,6 +392,7 @@ function updateTableProgress(tables, state, currentTable) {
             + icon
             + '<span class="text-sm font-medium text-text flex-1 truncate">' + t.table + '</span>'
             + '<span class="text-xs text-textMuted whitespace-nowrap flex-shrink-0">' + rowsText + '</span>'
+            + timingLabel
             + miniBar
             + '</div>';
     }).join('');
@@ -351,6 +402,12 @@ function setCheckboxesDisabled(disabled) {
     document.querySelectorAll('.table-checkbox').forEach(function(cb) { cb.disabled = disabled; });
     var sa = document.getElementById('select-all-checkbox');
     if (sa) sa.disabled = disabled;
+}
+
+function fmtMs(ms) {
+    if (!ms) return '—';
+    if (ms < 1000) return ms + 'ms';
+    return (ms / 1000).toFixed(1) + 's';
 }
 
 function fmtNum(n) { return (n || 0).toLocaleString(); }

--- a/cmd/app/dashboard/pages/snapshot.html
+++ b/cmd/app/dashboard/pages/snapshot.html
@@ -340,7 +340,7 @@ function updateRunningUI(data) {
     document.getElementById('run-total-rows').textContent = fmtNum(totalRows);
     document.getElementById('run-current-table').textContent = data.current_table || '—';
 
-    var pct = totalRows > 0 ? Math.round((readRows / totalRows) * 100) : 0;
+    var pct = totalRows > 0 ? Math.min(100, Math.round((readRows / totalRows) * 100)) : 0;
     document.getElementById('run-progress-bar').style.width = pct + '%';
     document.getElementById('run-pct').textContent = pct + '%';
 
@@ -348,7 +348,7 @@ function updateRunningUI(data) {
     document.getElementById('run-build-ms').textContent = fmtMs(data.build_ms);
     document.getElementById('run-transform-ms').textContent = fmtMs(data.transform_ms);
     document.getElementById('run-write-ms').textContent = fmtMs(data.write_ms);
-    document.getElementById('run-rows-per-sec').textContent = data.read_rows_per_sec ? data.read_rows_per_sec.toFixed(1) + ' r/s' : '—';
+    document.getElementById('run-rows-per-sec').textContent = data.read_rows_per_sec != null ? data.read_rows_per_sec.toFixed(1) + ' r/s' : '—';
 
     var errEl = document.getElementById('run-error');
     if (data.error) { errEl.textContent = 'Error: ' + data.error; errEl.classList.remove('hidden'); }
@@ -368,25 +368,27 @@ function updateTableProgress(tables, state, currentTable) {
     document.getElementById('tables-list').innerHTML = tables.map(function(t) {
         var hasTotal = t.total_rows > 0;
         var pct = hasTotal ? Math.min(100, Math.round((t.read_rows / t.total_rows) * 100)) : (t.done ? 100 : 0);
+        var isActive = !t.done && t.table === currentTable;
+
+        var icon, rowBg, barColor;
+        if (t.done) {
+            icon = checkIcon; rowBg = 'bg-success/5 border-success/20'; barColor = 'bg-success';
+        } else if (isActive) {
+            icon = spinIcon; rowBg = 'bg-primary/5 border-primary/20'; barColor = 'bg-primary';
+        } else {
+            icon = dbIcon; rowBg = 'bg-surfaceHover border-border'; barColor = 'bg-border';
+        }
+
         var rowsText = hasTotal
             ? fmtNum(t.read_rows) + ' / ' + fmtNum(t.total_rows)
             : (t.done ? 'Done' : (state === 'running' ? 'Waiting...' : '—'));
-        var isActive = !t.done && t.table === currentTable;
 
-        var rowBg, icon, barColor;
-        if (t.done) {
-            rowBg = 'bg-success/5 border-success/20'; barColor = 'bg-success'; icon = checkIcon;
-        } else if (isActive) {
-            rowBg = 'bg-primary/5 border-primary/20'; barColor = 'bg-primary'; icon = spinIcon;
-        } else {
-            rowBg = 'bg-surfaceHover border-border'; barColor = 'bg-border'; icon = dbIcon;
+        var timingLabel = '<span class="flex flex-wrap items-center gap-x-2 text-xs text-textMuted font-mono flex-shrink-0"><span>R:' + fmtMs(t.read_ms) + '</span><span>B:' + fmtMs(t.build_ms) + '</span><span>T:' + fmtMs(t.transform_ms) + '</span><span>W:' + fmtMs(t.write_ms) + '</span></span>';
+
+        var miniBar = '';
+        if (hasTotal) {
+            miniBar = '<div class="w-24 bg-border rounded-full h-1.5 flex-shrink-0"><div class="' + barColor + ' h-1.5 rounded-full transition-all duration-300" style="width:' + pct + '%"></div></div>';
         }
-
-        var timingLabel = '<span class="text-xs text-textMuted font-mono flex-shrink-0">R:' + fmtMs(t.read_ms) + ' B:' + fmtMs(t.build_ms) + ' T:' + fmtMs(t.transform_ms) + ' W:' + fmtMs(t.write_ms) + '</span>';
-
-        var miniBar = hasTotal
-            ? '<div class="w-24 bg-border rounded-full h-1.5 flex-shrink-0"><div class="' + barColor + ' h-1.5 rounded-full transition-all duration-300" style="width:' + pct + '%"></div></div>'
-            : '';
 
         return '<div class="flex items-center gap-3 p-3 rounded-lg ' + rowBg + ' border transition-colors duration-200">'
             + icon

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -1695,10 +1695,27 @@ func (s *Server) handleSnapshotStatus(c *xun.Context) error {
 	tables := make([]map[string]interface{}, len(progress.Tables))
 	for i, tp := range progress.Tables {
 		tables[i] = map[string]interface{}{
-			"table":      tp.Table,
-			"total_rows": tp.TotalRows,
-			"read_rows":  tp.ReadRows,
+			"table":        tp.Table,
+			"total_rows":   tp.TotalRows,
+			"read_rows":    tp.ReadRows,
+			"read_ms":      tp.ReadMs,
+			"build_ms":     tp.BuildMs,
+			"transform_ms": tp.TransformMs,
+			"write_ms":     tp.WriteMs,
 		}
+	}
+
+	// Accumulate global timing totals.
+	var acc struct{ read, build, transform, write int64 }
+	for _, tp := range progress.Tables {
+		acc.read += tp.ReadMs
+		acc.build += tp.BuildMs
+		acc.transform += tp.TransformMs
+		acc.write += tp.WriteMs
+	}
+	readRowsPerSec := float64(0)
+	if acc.read > 0 {
+		readRowsPerSec = float64(progress.ReadRows) * 1000 / float64(acc.read)
 	}
 
 	var startTimeStr, endTimeStr string
@@ -1710,18 +1727,23 @@ func (s *Server) handleSnapshotStatus(c *xun.Context) error {
 	}
 
 	return c.View(map[string]any{
-		"success":       true,
-		"state":         state,
-		"total":         progress.TotalTables,
-		"total_rows":    progress.TotalRows,
-		"read_rows":     progress.ReadRows,
-		"current_table": progress.CurrentTable,
-		"tables":        tables,
-		"started":       progress.Started,
-		"completed":     progress.Completed,
-		"error":         progress.Error,
-		"start_time":    startTimeStr,
-		"end_time":      endTimeStr,
+		"success":          true,
+		"state":            state,
+		"total":            progress.TotalTables,
+		"total_rows":       progress.TotalRows,
+		"read_rows":        progress.ReadRows,
+		"current_table":    progress.CurrentTable,
+		"tables":           tables,
+		"started":          progress.Started,
+		"completed":        progress.Completed,
+		"error":            progress.Error,
+		"start_time":       startTimeStr,
+		"end_time":         endTimeStr,
+		"read_ms":          acc.read,
+		"build_ms":         acc.build,
+		"transform_ms":     acc.transform,
+		"write_ms":         acc.write,
+		"read_rows_per_sec": readRowsPerSec,
 	})
 }
 


### PR DESCRIPTION
Fixes: #256

## What Changed

**Backend (internal/snapshot/capturer.go, cmd/app/server.go):**
- Added global `ReadMs/BuildMs/TransformMs/WriteMs` fields to `Progress` struct
- `Progress()` method now computes sum of per-table timings as global values
- API computes `read_rows_per_sec = ReadRows * 1000 / ReadMs`
- API serializes per-table `read_ms/build_ms/transform_ms/write_ms` fields

**Frontend (cmd/app/dashboard/pages/snapshot.html):**
- Added global four-phase summary cards displaying total timing
- Per-table rows now show `R:/B:/T:/W:` inline timing labels
- `fmtMs(0)` renders as `—`, `fmtMs(340)` as `340ms`, `fmtMs(1200)` as `1.2s`

## Why Changed

Users could not see phase-level timing breakdown to identify bottlenecks. Snapshot performance optimization was impossible without visibility. This fix completes the data chain from backend to UI, providing Read/Build/Transform/Write timing per table and globally.

## How to Test

1. **API verification:**
   - Call snapshot progress API and confirm per-table objects include `read_ms/build_ms/transform_ms/write_ms`
   - Confirm top-level response includes global timing fields and `read_rows_per_sec`

2. **Dashboard verification:**
   - Navigate to snapshot dashboard
   - Verify four global cards display formatted timing values (`—` for null/zero)
   - Verify Read card shows rows/s throughput
   - Verify per-table rows display `R:`, `B:`, `T:`, `W:` labels with timing values inline

3. **Format verification:**
   - `fmtMs(0)` → `—`
   - `fmtMs(340)` → `340ms`
   - `fmtMs(1200)` → `1.2s`

## Files Modified
- `cmd/app/server.go`
- `internal/snapshot/capturer.go`
- `cmd/app/dashboard/pages/snapshot.html`