### PR TITLE
feat(dashboard): persist per-table snapshot phase timing after completion

### DIFF
--- a/cmd/app/dashboard/pages/snapshot.html
+++ b/cmd/app/dashboard/pages/snapshot.html
@@ -79,6 +79,8 @@
                 <p id="run-rows-per-sec" class="text-sm font-bold text-text font-mono">—</p>
             </div>
         </div>
+        <!-- Per-table breakdown (always visible while timing panel is shown) -->
+        <div id="timing-breakdown" class="mt-4 overflow-x-auto"></div>
     </div>
 
     <!-- Completion Summary Panel -->
@@ -299,7 +301,6 @@ function showRunningPanel() {
 }
 function hideRunningPanel() {
     document.getElementById('panel-running').classList.add('hidden');
-    document.getElementById('panel-timing').classList.add('hidden');
 }
 
 function hideSummaryPanel() {
@@ -314,6 +315,14 @@ function showTimingPanel() {
 function showSummaryPanel(data) {
     document.getElementById('panel-summary').classList.remove('hidden');
     showTimingPanel();
+    if (data.tables && data.tables.length > 0) {
+        document.getElementById('run-read-ms').textContent = fmtMs(data.read_ms);
+        document.getElementById('run-build-ms').textContent = fmtMs(data.build_ms);
+        document.getElementById('run-transform-ms').textContent = fmtMs(data.transform_ms);
+        document.getElementById('run-write-ms').textContent = fmtMs(data.write_ms);
+        document.getElementById('run-rows-per-sec').textContent = data.read_rows_per_sec != null ? data.read_rows_per_sec.toFixed(1) + ' r/s' : '—';
+        renderTimingBreakdown(data.tables, data.state || 'completed');
+    }
     document.getElementById('sum-tables').textContent = (data.processed || 0) + ' / ' + (data.total || 0);
     document.getElementById('sum-rows').textContent = fmtNum(data.read_rows || 0);
     if (data.start_time) {
@@ -356,6 +365,7 @@ function updateRunningUI(data) {
 
     if (data.tables && data.tables.length > 0) {
         updateTableProgress(data.tables, data.state, data.current_table);
+        renderTimingBreakdown(data.tables, data.state);
     }
 }
 
@@ -404,6 +414,43 @@ function setCheckboxesDisabled(disabled) {
     document.querySelectorAll('.table-checkbox').forEach(function(cb) { cb.disabled = disabled; });
     var sa = document.getElementById('select-all-checkbox');
     if (sa) sa.disabled = disabled;
+}
+
+function renderTimingBreakdown(tables, state) {
+    var el = document.getElementById('timing-breakdown');
+    if (!el || !tables || tables.length === 0) return;
+    var checkIcon = '<svg class="w-3.5 h-3.5 text-success inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>';
+    var spinIcon  = '<svg class="w-3.5 h-3.5 text-primary animate-spin inline-block mr-1" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
+    var waitIcon  = '<svg class="w-3.5 h-3.5 text-textMuted/40 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke-width="2"/></svg>';
+    var rows = tables.map(function(t) {
+        var isDone   = !!t.done;
+        var isActive = !isDone && state === 'running' && (t.read_ms > 0 || t.build_ms > 0);
+        var icon = isDone ? checkIcon : (isActive ? spinIcon : waitIcon);
+        var nameColor = isDone ? 'text-text' : (isActive ? 'text-primary' : 'text-textMuted');
+        var rowBg = isDone ? '' : (isActive ? 'bg-primary/5' : '');
+        var total = (t.read_ms || 0) + (t.build_ms || 0) + (t.transform_ms || 0) + (t.write_ms || 0);
+        var totalCell = total > 0
+            ? '<span class="font-semibold ' + (isDone ? 'text-text' : 'text-primary') + '">' + fmtMs(total) + '</span>'
+            : '<span class="text-textMuted/40">—</span>';
+        return '<tr class="border-b border-border/40 last:border-0 ' + rowBg + '">'
+            + '<td class="py-2 pr-4 whitespace-nowrap text-sm ' + nameColor + ' font-medium">' + icon + t.table + '</td>'
+            + '<td class="py-2 px-3 text-center font-mono text-xs">' + fmtMs(t.read_ms) + '</td>'
+            + '<td class="py-2 px-3 text-center font-mono text-xs">' + fmtMs(t.build_ms) + '</td>'
+            + '<td class="py-2 px-3 text-center font-mono text-xs">' + fmtMs(t.transform_ms) + '</td>'
+            + '<td class="py-2 px-3 text-center font-mono text-xs">' + fmtMs(t.write_ms) + '</td>'
+            + '<td class="py-2 pl-3 text-right font-mono text-xs">' + totalCell + '</td>'
+            + '</tr>';
+    });
+    el.innerHTML = '<table class="w-full text-sm border-collapse">'
+        + '<thead><tr class="border-b border-border">'
+        + '<th class="pb-2 pr-4 text-left text-xs font-semibold text-textMuted uppercase tracking-wide">Table</th>'
+        + '<th class="pb-2 px-3 text-center text-xs font-semibold text-textMuted uppercase tracking-wide" title="Phase A: SQL query time">A Read</th>'
+        + '<th class="pb-2 px-3 text-center text-xs font-semibold text-textMuted uppercase tracking-wide" title="Phase B: Row assembly time">B Build</th>'
+        + '<th class="pb-2 px-3 text-center text-xs font-semibold text-textMuted uppercase tracking-wide" title="Phase C: Transform/skills time">C Transform</th>'
+        + '<th class="pb-2 px-3 text-center text-xs font-semibold text-textMuted uppercase tracking-wide" title="Phase D: Sink write time">D Write</th>'
+        + '<th class="pb-2 pl-3 text-right text-xs font-semibold text-textMuted uppercase tracking-wide">Total</th>'
+        + '</tr></thead>'
+        + '<tbody>' + rows.join('') + '</tbody></table>';
 }
 
 function fmtMs(ms) {

--- a/cmd/app/dashboard/pages/snapshot.html
+++ b/cmd/app/dashboard/pages/snapshot.html
@@ -139,7 +139,8 @@ var MAX_FAILURES = 5;
 var staticTables = [];
 var snapshotStartTime = null;
 
-// Init
+// Init — render Start Snapshot immediately so the header is never empty while status loads.
+renderButton('idle');
 loadTables();
 checkInitialStatus();
 

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -1698,6 +1698,7 @@ func (s *Server) handleSnapshotStatus(c *xun.Context) error {
 			"table":        tp.Table,
 			"total_rows":   tp.TotalRows,
 			"read_rows":    tp.ReadRows,
+			"done":         tp.Done,
 			"read_ms":      tp.ReadMs,
 			"build_ms":     tp.BuildMs,
 			"transform_ms": tp.TransformMs,

--- a/internal/snapshot/capturer.go
+++ b/internal/snapshot/capturer.go
@@ -46,6 +46,7 @@ type TableProgress struct {
 	Table       string
 	TotalRows   int64
 	ReadRows    int64
+	Done        bool  // true when all rows for this table have been read
 	ReadMs      int64 // Phase A: time spent reading rows from DB
 	BuildMs     int64 // Phase B: time spent building/assembling the batch
 	TransformMs int64 // Phase C: time spent in Transform
@@ -304,6 +305,7 @@ func (c *SnapshotCapturer) Progress() Progress {
 	for i, t := range c.tables {
 		tp := TableProgress{
 			Table: t.FullName(),
+			Done:  c.completed || i < c.tableIndex,
 		}
 		if i < len(c.tableTotals) {
 			tp.TotalRows = c.tableTotals[i]


### PR DESCRIPTION
## Summary

After a snapshot finishes, the dashboard timing panel now keeps a **per-table breakdown** (Read / Build / Transform / Write + total), so users still see each table's phase timings alongside the aggregate cards.

## Changes

- **API:** Add `done` to each entry in `/api/snapshot/status` `tables` array (`TableProgress.Done` in snapshot capturer).
- **UI:** Add `timing-breakdown` table under Phase Timing; populate during run and on completion (`showSummaryPanel`).
- **UI:** `hideRunningPanel()` no longer hides the timing panel (avoids losing breakdown when switching from running to completed).

## Testing

- `go test ./...` (via pre-commit hook before lint step).
- Manual: run snapshot, confirm breakdown visible after **Snapshot Completed**.

Made with [Cursor](https://cursor.com)